### PR TITLE
perf: bounded low latency packet queue

### DIFF
--- a/addons/nightfall-stream/CMakeLists.txt
+++ b/addons/nightfall-stream/CMakeLists.txt
@@ -142,7 +142,7 @@ endif()
 
 if(ANDROID)
     target_compile_definitions(${LIBNAME} PRIVATE _FORTIFY_SOURCE=0)
-    target_link_libraries(${LIBNAME} PRIVATE atomic m log)
+    target_link_libraries(${LIBNAME} PRIVATE atomic m log dl android mediandk)
 endif()
 
 if(WIN32)

--- a/addons/nightfall-stream/CMakeLists.txt
+++ b/addons/nightfall-stream/CMakeLists.txt
@@ -9,6 +9,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
 endif()
 
 project(${LIBNAME} LANGUAGES CXX)
+include(CTest)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -182,5 +183,14 @@ if(TARGET_PLATFORM STREQUAL "linux" OR TARGET_PLATFORM STREQUAL "steamos")
             ${FFMPEG_LIBRARIES}
             pthread dl
         )
+
+        if(BUILD_TESTING)
+            add_executable(decode_unit_queue_test
+                "${CMAKE_CURRENT_SOURCE_DIR}/../../test/decode_unit_queue_test.cpp")
+            target_compile_features(decode_unit_queue_test PRIVATE cxx_std_17)
+            target_include_directories(decode_unit_queue_test PRIVATE src ${FFMPEG_INCLUDE_DIRS})
+            target_link_libraries(decode_unit_queue_test PRIVATE ${FFMPEG_LIBRARIES})
+            add_test(NAME decode_unit_queue COMMAND decode_unit_queue_test)
+        endif()
     endif()
 endif()

--- a/addons/nightfall-stream/src/video/decode_unit_queue.h
+++ b/addons/nightfall-stream/src/video/decode_unit_queue.h
@@ -1,0 +1,124 @@
+#pragma once
+
+extern "C" {
+#include <libavcodec/packet.h>
+}
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <optional>
+#include <utility>
+
+namespace godot {
+
+// Owns a small FIFO of compressed decode units and recovers safely from
+// overload. Once any dependent unit is discarded, only a later IDR starts a
+// new decodable sequence.
+class DecodeUnitQueue {
+public:
+    static constexpr size_t kDefaultCapacity = 4;
+
+    struct PacketDeleter {
+        void operator()(AVPacket *packet) const {
+            av_packet_free(&packet);
+        }
+    };
+
+    using PacketPtr = std::unique_ptr<AVPacket, PacketDeleter>;
+
+    struct DecodeUnit {
+        PacketPtr packet;
+        bool is_idr = false;
+        int frame_number = 0;
+        int64_t presentation_time_us = 0;
+    };
+
+    struct PushResult {
+        bool accepted = false;
+        bool request_idr = false;
+        size_t dropped = 0;
+    };
+
+    explicit DecodeUnitQueue(size_t capacity = kDefaultCapacity)
+        : capacity_(capacity) {}
+
+    // Takes ownership of `unit`. On overflow, drops the obsolete reference
+    // chain and accepts only the next IDR, rather than decoding stale work.
+    PushResult push(DecodeUnit unit) {
+        if (awaiting_idr_) {
+            if (!unit.is_idr) {
+                return {false, false, 1};
+            }
+
+            const size_t dropped = units_.size();
+            units_.clear();
+            awaiting_idr_ = false;
+            units_.push_back(std::move(unit));
+            return {true, false, dropped};
+        }
+
+        if (units_.size() < capacity_) {
+            units_.push_back(std::move(unit));
+            return {true, false, 0};
+        }
+
+        // A fresh IDR is independently decodable, so it can replace an old
+        // backlog immediately. Other units require an IDR resynchronization.
+        if (unit.is_idr) {
+            const size_t dropped = units_.size();
+            units_.clear();
+            units_.push_back(std::move(unit));
+            return {true, false, dropped};
+        }
+
+        const size_t dropped = units_.size() + 1;
+        units_.clear();
+        awaiting_idr_ = true;
+        return {false, true, dropped};
+    }
+
+    std::optional<DecodeUnit> pop() {
+        if (units_.empty()) {
+            return std::nullopt;
+        }
+
+        DecodeUnit unit = std::move(units_.front());
+        units_.pop_front();
+        return unit;
+    }
+
+    // Restores a unit after decoder input backpressure. If producers filled
+    // the vacated slot first, discard the stale sequence and request an IDR.
+    PushResult return_front(DecodeUnit unit) {
+        if (awaiting_idr_) {
+            return {false, false, 1};
+        }
+        if (units_.size() < capacity_) {
+            units_.push_front(std::move(unit));
+            return {true, false, 0};
+        }
+
+        const size_t dropped = units_.size() + 1;
+        units_.clear();
+        awaiting_idr_ = true;
+        return {false, true, dropped};
+    }
+
+    void clear() {
+        units_.clear();
+        awaiting_idr_ = false;
+    }
+
+    bool empty() const { return units_.empty(); }
+    size_t size() const { return units_.size(); }
+    bool awaiting_idr() const { return awaiting_idr_; }
+
+private:
+    const size_t capacity_;
+    std::deque<DecodeUnit> units_;
+    bool awaiting_idr_ = false;
+};
+
+} // namespace godot

--- a/addons/nightfall-stream/src/video/mediacodec_native.cpp
+++ b/addons/nightfall-stream/src/video/mediacodec_native.cpp
@@ -3,9 +3,25 @@
 #ifdef __ANDROID__
 #include "nf_log.h"
 #include <cstring>
+#include <dlfcn.h>
 #include <unistd.h>
 
 namespace godot {
+
+namespace {
+using AHardwareBufferGetIdFn = int (*)(const AHardwareBuffer *, uint64_t *);
+
+AHardwareBufferGetIdFn get_hardware_buffer_id_fn() {
+    static auto fn = reinterpret_cast<AHardwareBufferGetIdFn>(
+        dlsym(RTLD_DEFAULT, "AHardwareBuffer_getId"));
+    return fn;
+}
+
+bool query_hardware_buffer_id(AHardwareBuffer *buffer, uint64_t &out_id) {
+    auto fn = get_hardware_buffer_id_fn();
+    return buffer && fn && fn(buffer, &out_id) == 0 && out_id != 0;
+}
+} // namespace
 
 AndroidMediaCodec::AndroidMediaCodec() = default;
 
@@ -26,9 +42,23 @@ bool AndroidMediaCodec::init(const char *mime, int width, int height) {
         return false;
     }
 
+    AImageReader_BufferRemovedListener listener{};
+    listener.context = this;
+    listener.onBufferRemoved = &AndroidMediaCodec::_on_buffer_removed;
+    status = AImageReader_setBufferRemovedListener(reader_, &listener);
+    if (status == AMEDIA_OK) {
+        buffer_cache_supported_.store(true);
+        NF_LOG("AndroidMediaCodec", "AHardwareBuffer import cache enabled (%s keys)",
+               get_hardware_buffer_id_fn() ? "stable ID" : "opaque handle");
+    } else {
+        // Decoding remains available with the original per-frame import path.
+        NF_LOGE("AndroidMediaCodec", "AHardwareBuffer import cache disabled; buffer listener failed: %d", status);
+    }
+
     status = AImageReader_getWindow(reader_, &window_);
     if (status != AMEDIA_OK || !window_) {
         NF_LOGE("AndroidMediaCodec", "AImageReader_getWindow failed: %d", status);
+        buffer_cache_supported_.store(false);
         AImageReader_delete(reader_);
         reader_ = nullptr;
         return false;
@@ -109,9 +139,40 @@ void AndroidMediaCodec::shutdown() {
         window_ = nullptr;
     }
     if (reader_) {
+        buffer_cache_supported_.store(false);
         AImageReader_delete(reader_);
         reader_ = nullptr;
     }
+    {
+        std::lock_guard<std::mutex> lock(removed_buffers_mutex_);
+        removed_buffer_ids_.clear();
+    }
+}
+
+bool AndroidMediaCodec::get_buffer_id(AHardwareBuffer *buffer, uint64_t &out_id) const {
+    return buffer_cache_supported_.load() && query_hardware_buffer_id(buffer, out_id);
+}
+
+void AndroidMediaCodec::take_removed_buffer_ids(std::vector<uint64_t> &out_ids) {
+    std::lock_guard<std::mutex> lock(removed_buffers_mutex_);
+    out_ids.swap(removed_buffer_ids_);
+}
+
+void AndroidMediaCodec::_on_buffer_removed(void *context, AImageReader *,
+                                            AHardwareBuffer *buffer) {
+    auto *self = static_cast<AndroidMediaCodec *>(context);
+    if (!self || !self->buffer_cache_supported_.load()) return;
+
+    uint64_t buffer_id = 0;
+    if (!query_hardware_buffer_id(buffer, buffer_id)) {
+        // API 26-30 have removal callbacks but no documented stable ID API.
+        // Retained imported memory keeps this opaque handle alive, so use the
+        // same best-effort identity as the decode path on those releases.
+        buffer_id = (uint64_t)buffer;
+    }
+
+    std::lock_guard<std::mutex> lock(self->removed_buffers_mutex_);
+    self->removed_buffer_ids_.push_back(buffer_id);
 }
 
 bool AndroidMediaCodec::feed_packet(const uint8_t *data, size_t size, int64_t pts) {

--- a/addons/nightfall-stream/src/video/mediacodec_native.cpp
+++ b/addons/nightfall-stream/src/video/mediacodec_native.cpp
@@ -2,9 +2,10 @@
 
 #ifdef __ANDROID__
 #include "nf_log.h"
+#include <chrono>
 #include <cstring>
 #include <dlfcn.h>
-#include <unistd.h>
+#include <utility>
 
 namespace godot {
 
@@ -29,23 +30,58 @@ AndroidMediaCodec::~AndroidMediaCodec() {
     shutdown();
 }
 
-bool AndroidMediaCodec::init(const char *mime, int width, int height) {
-    width_ = width;
-    height_ = height;
+void AndroidMediaCodec::_reset_event_state() {
+    std::lock_guard<std::mutex> lock(event_mutex_);
+    available_input_indices_.clear();
+    available_output_events_.clear();
+    pending_output_ = OutputEvent{};
+    pending_output_valid_ = false;
+    image_event_generation_ = 0;
+    stopping_ = false;
+    async_error_ = AMEDIA_OK;
+}
 
-    // Create ImageReader with GPU sampling usage for direct Vulkan import
+bool AndroidMediaCodec::init(const char *mime, int width, int height,
+                             EventNotifier event_notifier) {
+    shutdown();
+
+    width_.store(width);
+    height_.store(height);
+    eos_.store(false);
+    buffer_cache_supported_.store(false);
+    {
+        std::lock_guard<std::mutex> lock(event_mutex_);
+        event_notifier_ = std::move(event_notifier);
+    }
+    _reset_event_state();
+
+    // Create ImageReader with GPU sampling usage for direct Vulkan import.
     media_status_t status = AImageReader_newWithUsage(
-        width_, height_, AIMAGE_FORMAT_YUV_420_888,
-        AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE | AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN | AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN, 4, &reader_);
+        width, height, AIMAGE_FORMAT_YUV_420_888,
+        AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE |
+            AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN |
+            AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN,
+        4, &reader_);
     if (status != AMEDIA_OK || !reader_) {
         NF_LOGE("AndroidMediaCodec", "AImageReader_newWithUsage failed: %d", status);
+        shutdown();
         return false;
     }
 
-    AImageReader_BufferRemovedListener listener{};
-    listener.context = this;
-    listener.onBufferRemoved = &AndroidMediaCodec::_on_buffer_removed;
-    status = AImageReader_setBufferRemovedListener(reader_, &listener);
+    AImageReader_ImageListener image_listener{};
+    image_listener.context = this;
+    image_listener.onImageAvailable = &AndroidMediaCodec::_on_image_available;
+    status = AImageReader_setImageListener(reader_, &image_listener);
+    if (status != AMEDIA_OK) {
+        NF_LOGE("AndroidMediaCodec", "AImageReader_setImageListener failed: %d", status);
+        shutdown();
+        return false;
+    }
+
+    AImageReader_BufferRemovedListener buffer_listener{};
+    buffer_listener.context = this;
+    buffer_listener.onBufferRemoved = &AndroidMediaCodec::_on_buffer_removed;
+    status = AImageReader_setBufferRemovedListener(reader_, &buffer_listener);
     if (status == AMEDIA_OK) {
         buffer_cache_supported_.store(true);
         NF_LOG("AndroidMediaCodec", "AHardwareBuffer import cache enabled (%s keys)",
@@ -58,24 +94,29 @@ bool AndroidMediaCodec::init(const char *mime, int width, int height) {
     status = AImageReader_getWindow(reader_, &window_);
     if (status != AMEDIA_OK || !window_) {
         NF_LOGE("AndroidMediaCodec", "AImageReader_getWindow failed: %d", status);
-        buffer_cache_supported_.store(false);
-        AImageReader_delete(reader_);
-        reader_ = nullptr;
+        shutdown();
         return false;
     }
 
-    // Create and configure MediaCodec
     codec_ = AMediaCodec_createDecoderByType(mime);
     if (!codec_) {
         NF_LOGE("AndroidMediaCodec", "AMediaCodec_createDecoderByType failed for %s", mime);
-        ANativeWindow_release(window_);
-        window_ = nullptr;
-        AImageReader_delete(reader_);
-        reader_ = nullptr;
+        shutdown();
         return false;
     }
 
-    // Configure with the ImageReader's ANativeWindow for Surface output
+    AMediaCodecOnAsyncNotifyCallback callbacks{};
+    callbacks.onAsyncInputAvailable = &AndroidMediaCodec::_on_async_input_available;
+    callbacks.onAsyncOutputAvailable = &AndroidMediaCodec::_on_async_output_available;
+    callbacks.onAsyncFormatChanged = &AndroidMediaCodec::_on_async_format_changed;
+    callbacks.onAsyncError = &AndroidMediaCodec::_on_async_error;
+    status = AMediaCodec_setAsyncNotifyCallback(codec_, callbacks, this);
+    if (status != AMEDIA_OK) {
+        NF_LOGE("AndroidMediaCodec", "AMediaCodec_setAsyncNotifyCallback failed: %d", status);
+        shutdown();
+        return false;
+    }
+
     AMediaFormat *format = AMediaFormat_new();
     AMediaFormat_setString(format, AMEDIAFORMAT_KEY_MIME, mime);
     AMediaFormat_setInt32(format, AMEDIAFORMAT_KEY_WIDTH, width);
@@ -84,69 +125,176 @@ bool AndroidMediaCodec::init(const char *mime, int width, int height) {
 
     status = AMediaCodec_configure(codec_, format, window_, nullptr, 0);
     AMediaFormat_delete(format);
-
     if (status != AMEDIA_OK) {
         NF_LOGE("AndroidMediaCodec", "AMediaCodec_configure failed: %d", status);
-        AMediaCodec_delete(codec_);
-        codec_ = nullptr;
-        ANativeWindow_release(window_);
-        window_ = nullptr;
-        AImageReader_delete(reader_);
-        reader_ = nullptr;
+        shutdown();
         return false;
     }
 
+    // Input callbacks may be delivered as AMediaCodec_start() completes.
+    started_.store(true);
     status = AMediaCodec_start(codec_);
     if (status != AMEDIA_OK) {
+        started_.store(false);
         NF_LOGE("AndroidMediaCodec", "AMediaCodec_start failed: %d", status);
-        AMediaCodec_delete(codec_);
-        codec_ = nullptr;
-        ANativeWindow_release(window_);
-        window_ = nullptr;
-        AImageReader_delete(reader_);
-        reader_ = nullptr;
+        shutdown();
         return false;
     }
 
-    started_.store(true);
-    eos_.store(false);
-    input_pts_counter_ = 0;
-    NF_LOG("AndroidMediaCodec", "Initialized: %dx%d mime=%s", width, height, mime);
+    NF_LOG("AndroidMediaCodec", "Initialized async codec: %dx%d mime=%s", width, height, mime);
     return true;
 }
 
 void AndroidMediaCodec::shutdown() {
-    started_.store(false);
+    const bool was_started = started_.exchange(false);
+    buffer_cache_supported_.store(false);
+    {
+        std::lock_guard<std::mutex> lock(event_mutex_);
+        stopping_ = true;
+    }
+    event_cv_.notify_all();
+    _notify_event();
+
+    // Unregister native callbacks before destroying their context. The NDK
+    // guarantees codec callbacks are not delivered after unregistration.
     if (codec_) {
-        // Send EOS to flush
-        if (!eos_.load()) {
-            ssize_t idx = AMediaCodec_dequeueInputBuffer(codec_, 1000);
-            if (idx >= 0) {
-                size_t buf_size;
-                uint8_t *buf = AMediaCodec_getInputBuffer(codec_, (size_t)idx, &buf_size);
-                if (buf) {
-                    AMediaCodec_queueInputBuffer(codec_, (size_t)idx, 0, 0, 0,
-                        AMEDIACODEC_BUFFER_FLAG_END_OF_STREAM);
-                }
-            }
+        AMediaCodecOnAsyncNotifyCallback callbacks{};
+        AMediaCodec_setAsyncNotifyCallback(codec_, callbacks, nullptr);
+    }
+    if (reader_) {
+        AImageReader_setImageListener(reader_, nullptr);
+        AImageReader_setBufferRemovedListener(reader_, nullptr);
+    }
+
+    // Wait for a callback that entered immediately before unregistration.
+    {
+        std::lock_guard<std::mutex> callback_lock(callback_mutex_);
+    }
+
+    if (codec_) {
+        if (was_started) {
+            AMediaCodec_stop(codec_);
         }
-        AMediaCodec_stop(codec_);
         AMediaCodec_delete(codec_);
         codec_ = nullptr;
     }
-    if (window_) {
-        ANativeWindow_release(window_);
-        window_ = nullptr;
-    }
+
+    // AImageReader owns the ANativeWindow returned by getWindow().
+    window_ = nullptr;
     if (reader_) {
-        buffer_cache_supported_.store(false);
         AImageReader_delete(reader_);
         reader_ = nullptr;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(event_mutex_);
+        available_input_indices_.clear();
+        available_output_events_.clear();
+        pending_output_ = OutputEvent{};
+        pending_output_valid_ = false;
+        event_notifier_ = {};
     }
     {
         std::lock_guard<std::mutex> lock(removed_buffers_mutex_);
         removed_buffer_ids_.clear();
     }
+    eos_.store(false);
+}
+
+void AndroidMediaCodec::_notify_event() {
+    EventNotifier notifier;
+    {
+        std::lock_guard<std::mutex> lock(event_mutex_);
+        notifier = event_notifier_;
+    }
+    event_cv_.notify_all();
+    if (notifier) notifier();
+}
+
+void AndroidMediaCodec::_on_async_input_available(AMediaCodec *, void *userdata,
+                                                   int32_t index) {
+    auto *self = static_cast<AndroidMediaCodec *>(userdata);
+    if (!self) return;
+
+    std::lock_guard<std::mutex> callback_lock(self->callback_mutex_);
+    if (!self->started_.load()) return;
+    {
+        std::lock_guard<std::mutex> lock(self->event_mutex_);
+        if (self->stopping_) return;
+        self->available_input_indices_.push_back((size_t)index);
+    }
+    self->_notify_event();
+}
+
+void AndroidMediaCodec::_on_async_output_available(AMediaCodec *, void *userdata,
+                                                    int32_t index,
+                                                    AMediaCodecBufferInfo *info) {
+    auto *self = static_cast<AndroidMediaCodec *>(userdata);
+    if (!self || !info) return;
+
+    std::lock_guard<std::mutex> callback_lock(self->callback_mutex_);
+    if (!self->started_.load()) return;
+    {
+        std::lock_guard<std::mutex> lock(self->event_mutex_);
+        if (self->stopping_) return;
+
+        OutputEvent event;
+        event.index = (size_t)index;
+        event.info = *info;
+        event.width = self->width_.load();
+        event.height = self->height_.load();
+        self->available_output_events_.push_back(event);
+    }
+    self->_notify_event();
+}
+
+void AndroidMediaCodec::_on_async_format_changed(AMediaCodec *, void *userdata,
+                                                  AMediaFormat *format) {
+    auto *self = static_cast<AndroidMediaCodec *>(userdata);
+    if (!self || !format) return;
+
+    int32_t width = 0;
+    int32_t height = 0;
+    std::lock_guard<std::mutex> callback_lock(self->callback_mutex_);
+    if (!self->started_.load()) return;
+    AMediaFormat_getInt32(format, AMEDIAFORMAT_KEY_WIDTH, &width);
+    AMediaFormat_getInt32(format, AMEDIAFORMAT_KEY_HEIGHT, &height);
+    if (width > 0) self->width_.store(width);
+    if (height > 0) self->height_.store(height);
+    NF_LOG("AndroidMediaCodec", "Output format changed: %dx%d",
+           self->width_.load(), self->height_.load());
+    self->_notify_event();
+}
+
+void AndroidMediaCodec::_on_async_error(AMediaCodec *, void *userdata,
+                                         media_status_t error,
+                                         int32_t action_code,
+                                         const char *detail) {
+    auto *self = static_cast<AndroidMediaCodec *>(userdata);
+    if (!self) return;
+
+    std::lock_guard<std::mutex> callback_lock(self->callback_mutex_);
+    {
+        std::lock_guard<std::mutex> lock(self->event_mutex_);
+        self->async_error_ = error;
+    }
+    NF_LOGE("AndroidMediaCodec", "Async codec error=%d action=%d detail=%s",
+            error, action_code, detail ? detail : "");
+    self->_notify_event();
+}
+
+void AndroidMediaCodec::_on_image_available(void *context, AImageReader *) {
+    auto *self = static_cast<AndroidMediaCodec *>(context);
+    if (!self) return;
+
+    std::lock_guard<std::mutex> callback_lock(self->callback_mutex_);
+    if (!self->started_.load()) return;
+    {
+        std::lock_guard<std::mutex> lock(self->event_mutex_);
+        if (self->stopping_) return;
+        ++self->image_event_generation_;
+    }
+    self->_notify_event();
 }
 
 bool AndroidMediaCodec::get_buffer_id(AHardwareBuffer *buffer, uint64_t &out_id) const {
@@ -161,7 +309,10 @@ void AndroidMediaCodec::take_removed_buffer_ids(std::vector<uint64_t> &out_ids) 
 void AndroidMediaCodec::_on_buffer_removed(void *context, AImageReader *,
                                             AHardwareBuffer *buffer) {
     auto *self = static_cast<AndroidMediaCodec *>(context);
-    if (!self || !self->buffer_cache_supported_.load()) return;
+    if (!self) return;
+
+    std::lock_guard<std::mutex> callback_lock(self->callback_mutex_);
+    if (!self->buffer_cache_supported_.load()) return;
 
     uint64_t buffer_id = 0;
     if (!query_hardware_buffer_id(buffer, buffer_id)) {
@@ -175,121 +326,181 @@ void AndroidMediaCodec::_on_buffer_removed(void *context, AImageReader *,
     self->removed_buffer_ids_.push_back(buffer_id);
 }
 
-bool AndroidMediaCodec::feed_packet(const uint8_t *data, size_t size, int64_t pts) {
-    if (!started_.load() || !codec_) return false;
-
-    ssize_t idx = AMediaCodec_dequeueInputBuffer(codec_, 5000);
-    if (idx < 0) {
-        static int fail_count = 0;
-        if (++fail_count <= 3)
-            NF_LOGE("AndroidMediaCodec", "dequeueInputBuffer failed: %zd", (ssize_t)idx);
-        return false;
+AndroidMediaCodec::FeedResult AndroidMediaCodec::feed_packet(
+        const uint8_t *data, size_t size, int64_t pts) {
+    if (!data || size == 0 || !started_.load() || !codec_) {
+        return FeedResult::ERROR;
     }
 
-    size_t buf_size;
-    uint8_t *buf = AMediaCodec_getInputBuffer(codec_, (size_t)idx, &buf_size);
-    if (!buf || buf_size < size) {
+    size_t index = 0;
+    {
+        std::lock_guard<std::mutex> lock(event_mutex_);
+        if (stopping_ || async_error_ != AMEDIA_OK || !started_.load()) {
+            return FeedResult::ERROR;
+        }
+        if (available_input_indices_.empty()) {
+            return FeedResult::BACKPRESSURE;
+        }
+        index = available_input_indices_.front();
+        available_input_indices_.pop_front();
+    }
+
+    size_t buffer_size = 0;
+    uint8_t *buffer = AMediaCodec_getInputBuffer(codec_, index, &buffer_size);
+    if (!buffer || buffer_size < size) {
         static int fail_count = 0;
-        if (++fail_count <= 3)
+        if (++fail_count <= 3) {
             NF_LOGE("AndroidMediaCodec", "getInputBuffer failed: buf=%p size=%zu needed=%zu",
-                   (void*)buf, (size_t)buf_size, size);
-        return false;
+                    (void *)buffer, buffer_size, size);
+        }
+        // Return the callback-owned index to the codec instead of stranding it.
+        media_status_t return_status = AMediaCodec_queueInputBuffer(
+            codec_, index, 0, 0, (uint64_t)pts, 0);
+        if (return_status != AMEDIA_OK) {
+            NF_LOGE("AndroidMediaCodec", "Failed to return unusable input buffer: %d",
+                    return_status);
+        }
+        return FeedResult::ERROR;
     }
 
-    memcpy(buf, data, size);
-    uint32_t flags = 0;
-    AMediaCodec_queueInputBuffer(codec_, (size_t)idx, 0, size, (uint64_t)pts, flags);
-    return true;
+    memcpy(buffer, data, size);
+    media_status_t status = AMediaCodec_queueInputBuffer(
+        codec_, index, 0, size, (uint64_t)pts, 0);
+    if (status != AMEDIA_OK) {
+        static int fail_count = 0;
+        if (++fail_count <= 3) {
+            NF_LOGE("AndroidMediaCodec", "queueInputBuffer failed: %d", status);
+        }
+        return FeedResult::ERROR;
+    }
+    return FeedResult::QUEUED;
 }
 
-bool AndroidMediaCodec::dequeue_frame(NativeDecodedFrame &out_frame, int64_t timeout_us) {
+bool AndroidMediaCodec::dequeue_frame(NativeDecodedFrame &out_frame,
+                                       int64_t timeout_us) {
     if (!started_.load() || !codec_ || !reader_) return false;
 
-    AMediaCodecBufferInfo info;
-    ssize_t idx = AMediaCodec_dequeueOutputBuffer(codec_, &info, timeout_us);
+    const auto timeout = std::chrono::microseconds(timeout_us > 0 ? timeout_us : 0);
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
 
-    if (idx == AMEDIACODEC_INFO_OUTPUT_FORMAT_CHANGED) {
-        // Format changed - get new format
-        AMediaFormat *fmt = AMediaCodec_getOutputFormat(codec_);
-        if (fmt) {
-            int32_t w = 0, h = 0;
-            AMediaFormat_getInt32(fmt, AMEDIAFORMAT_KEY_WIDTH, &w);
-            AMediaFormat_getInt32(fmt, AMEDIAFORMAT_KEY_HEIGHT, &h);
-            if (w > 0) width_ = w;
-            if (h > 0) height_ = h;
-            NF_LOG("AndroidMediaCodec", "Output format changed: %dx%d", width_, height_);
-            AMediaFormat_delete(fmt);
+    {
+        std::unique_lock<std::mutex> lock(event_mutex_);
+        if (!pending_output_valid_) {
+            auto ready = [this] {
+                return !available_output_events_.empty() || stopping_ ||
+                       async_error_ != AMEDIA_OK || !started_.load();
+            };
+            if (!ready()) {
+                if (timeout_us <= 0 || !event_cv_.wait_until(lock, deadline, ready)) {
+                    return false;
+                }
+            }
+            if (stopping_ || async_error_ != AMEDIA_OK || !started_.load() ||
+                available_output_events_.empty()) {
+                return false;
+            }
+            pending_output_ = available_output_events_.front();
+            available_output_events_.pop_front();
+            pending_output_valid_ = true;
         }
-        return false;
     }
 
-    if (idx == AMEDIACODEC_INFO_OUTPUT_BUFFERS_CHANGED) {
-        return false;
-    }
-
-    if (idx == AMEDIACODEC_INFO_TRY_AGAIN_LATER) {
-        return false;
-    }
-
-    if (idx < 0) {
-        return false;
-    }
-
-    if (info.flags & AMEDIACODEC_BUFFER_FLAG_END_OF_STREAM) {
+    if (pending_output_.info.flags & AMEDIACODEC_BUFFER_FLAG_END_OF_STREAM) {
+        media_status_t status = AMediaCodec_releaseOutputBuffer(
+            codec_, pending_output_.index, false);
+        if (status != AMEDIA_OK) {
+            NF_LOGE("AndroidMediaCodec", "release EOS output failed: %d", status);
+        }
+        {
+            std::lock_guard<std::mutex> lock(event_mutex_);
+            pending_output_ = OutputEvent{};
+            pending_output_valid_ = false;
+        }
         eos_.store(true);
         return false;
     }
 
-    // Render the output buffer to the ImageReader Surface
-    AMediaCodec_releaseOutputBuffer(codec_, (size_t)idx, true);
+    if (!pending_output_.rendered) {
+        media_status_t status = AMediaCodec_releaseOutputBuffer(
+            codec_, pending_output_.index, true);
+        if (status != AMEDIA_OK) {
+            NF_LOGE("AndroidMediaCodec", "releaseOutputBuffer failed: %d", status);
+            std::lock_guard<std::mutex> lock(event_mutex_);
+            pending_output_ = OutputEvent{};
+            pending_output_valid_ = false;
+            return false;
+        }
+        pending_output_.rendered = true;
+    }
 
-    // Acquire the rendered image from ImageReader
     AImage *image = nullptr;
-    media_status_t status = AImageReader_acquireLatestImage(reader_, &image);
+    while (started_.load()) {
+        uint64_t observed_generation = 0;
+        {
+            std::lock_guard<std::mutex> lock(event_mutex_);
+            observed_generation = image_event_generation_;
+        }
 
-    if (status == AMEDIA_IMGREADER_NO_BUFFER_AVAILABLE) {
-        // Image not ready yet - retry with short wait
-        for (int retry = 0; retry < 10; retry++) {
-            usleep(1000); // 1ms
-            status = AImageReader_acquireLatestImage(reader_, &image);
-            if (status == AMEDIA_OK && image) break;
+        media_status_t status = AImageReader_acquireLatestImage(reader_, &image);
+        if (status == AMEDIA_OK && image) break;
+        if (status != AMEDIA_IMGREADER_NO_BUFFER_AVAILABLE) {
+            static int image_fail_count = 0;
+            if (++image_fail_count <= 3) {
+                NF_LOGE("AndroidMediaCodec", "acquireLatestImage failed: %d", status);
+            }
+            return false;
+        }
+
+        if (timeout_us <= 0) return false;
+        std::unique_lock<std::mutex> lock(event_mutex_);
+        bool signaled = event_cv_.wait_until(lock, deadline, [this, observed_generation] {
+            return image_event_generation_ != observed_generation || stopping_ ||
+                   async_error_ != AMEDIA_OK || !started_.load();
+        });
+        if (!signaled || stopping_ || async_error_ != AMEDIA_OK || !started_.load()) {
+            return false;
         }
     }
 
-    if (status != AMEDIA_OK || !image) {
-        static int imgfail = 0;
-        if (++imgfail <= 3)
-            NF_LOGE("AndroidMediaCodec", "acquireLatestImage failed: %d", status);
-        return false;
-    }
+    if (!image) return false;
 
-    AHardwareBuffer *ahb = nullptr;
-    status = AImage_getHardwareBuffer(image, &ahb);
-    if (status != AMEDIA_OK || !ahb) {
-        static int ahbfail = 0;
-        if (++ahbfail <= 3)
+    AHardwareBuffer *buffer = nullptr;
+    media_status_t status = AImage_getHardwareBuffer(image, &buffer);
+    if (status != AMEDIA_OK || !buffer) {
+        static int ahb_fail_count = 0;
+        if (++ahb_fail_count <= 3) {
             NF_LOGE("AndroidMediaCodec", "AImage_getHardwareBuffer failed: %d", status);
+        }
         AImage_delete(image);
+        std::lock_guard<std::mutex> lock(event_mutex_);
+        pending_output_ = OutputEvent{};
+        pending_output_valid_ = false;
         return false;
     }
 
-    AHardwareBuffer_acquire(ahb); // Add our reference
-
-    out_frame.buffer = ahb;
-    out_frame.pts = info.presentationTimeUs;
-    out_frame.width = width_;
-    out_frame.height = height_;
+    AHardwareBuffer_acquire(buffer);
+    out_frame.buffer = buffer;
+    out_frame.pts = pending_output_.info.presentationTimeUs;
+    out_frame.width = pending_output_.width;
+    out_frame.height = pending_output_.height;
     out_frame.image = image;
 
-    static int frame_count = 0;
-    if (++frame_count <= 5 || frame_count % 60 == 0)
-        NF_LOG("AndroidMediaCodec", "Frame ready: %dx%d pts=%lld buf=%p",
-               width_, height_, (long long)info.presentationTimeUs, (void*)ahb);
+    {
+        std::lock_guard<std::mutex> lock(event_mutex_);
+        pending_output_ = OutputEvent{};
+        pending_output_valid_ = false;
+    }
 
+    static int frame_count = 0;
+    if (++frame_count <= 5 || frame_count % 60 == 0) {
+        NF_LOG("AndroidMediaCodec", "Frame ready: %dx%d pts=%lld buf=%p",
+               out_frame.width, out_frame.height, (long long)out_frame.pts,
+               (void *)buffer);
+    }
     return true;
 }
 
-void AndroidMediaCodec::release_frame(NativeDecodedFrame &frame) {
+void AndroidMediaCodec::_release_frame_resources(NativeDecodedFrame &frame) {
     if (frame.image) {
         AImage_delete(frame.image);
         frame.image = nullptr;
@@ -298,6 +509,10 @@ void AndroidMediaCodec::release_frame(NativeDecodedFrame &frame) {
         AHardwareBuffer_release(frame.buffer);
         frame.buffer = nullptr;
     }
+}
+
+void AndroidMediaCodec::release_frame(NativeDecodedFrame &frame) {
+    _release_frame_resources(frame);
 }
 
 } // namespace godot

--- a/addons/nightfall-stream/src/video/mediacodec_native.h
+++ b/addons/nightfall-stream/src/video/mediacodec_native.h
@@ -7,7 +7,7 @@
 #include <android/native_window.h>
 #include <atomic>
 #include <mutex>
-#include <queue>
+#include <vector>
 #include <cstdint>
 
 namespace godot {
@@ -37,15 +37,26 @@ public:
     // Release a frame after Vulkan import. Call AImage_delete internally.
     void release_frame(NativeDecodedFrame &frame);
 
+    // Stable IDs are available on Android API 31+ and enable import caching.
+    bool is_import_cache_enabled() const { return buffer_cache_supported_.load(); }
+    bool get_buffer_id(AHardwareBuffer *buffer, uint64_t &out_id) const;
+    void take_removed_buffer_ids(std::vector<uint64_t> &out_ids);
+
     bool is_initialized() const { return codec_ != nullptr; }
 
 private:
+    static void _on_buffer_removed(void *context, AImageReader *reader,
+                                   AHardwareBuffer *buffer);
+
     AMediaCodec *codec_ = nullptr;
     AImageReader *reader_ = nullptr;
     ANativeWindow *window_ = nullptr;
     int width_ = 0, height_ = 0;
     std::atomic<bool> started_{false};
     std::atomic<bool> eos_{false};
+    std::atomic<bool> buffer_cache_supported_{false};
+    std::mutex removed_buffers_mutex_;
+    std::vector<uint64_t> removed_buffer_ids_;
     int64_t input_pts_counter_ = 0;
 };
 

--- a/addons/nightfall-stream/src/video/mediacodec_native.h
+++ b/addons/nightfall-stream/src/video/mediacodec_native.h
@@ -6,9 +6,12 @@
 #include <android/hardware_buffer.h>
 #include <android/native_window.h>
 #include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <functional>
 #include <mutex>
 #include <vector>
-#include <cstdint>
 
 namespace godot {
 
@@ -17,24 +20,37 @@ struct NativeDecodedFrame {
     int64_t pts = 0;
     int width = 0;
     int height = 0;
-    AImage *image = nullptr; // Must keep alive until Vulkan import completes
+    AImage *image = nullptr; // Owns the ImageReader slot until release_frame().
 };
 
+// Owns the asynchronous MediaCodec/ImageReader protocol. NDK callbacks only
+// publish events; the decode thread remains the sole consumer of frames.
 class AndroidMediaCodec {
 public:
+    using EventNotifier = std::function<void()>;
+
+    enum class FeedResult {
+        QUEUED,
+        BACKPRESSURE,
+        ERROR,
+    };
+
     AndroidMediaCodec();
     ~AndroidMediaCodec();
 
-    bool init(const char *mime, int width, int height);
+    bool init(const char *mime, int width, int height,
+              EventNotifier event_notifier = {});
     void shutdown();
 
-    // Feed raw HEVC/H.264 data (call from decode thread)
-    bool feed_packet(const uint8_t *data, size_t size, int64_t pts);
+    // Queues one compressed packet when an asynchronously supplied input index
+    // is ready, distinguishing retryable backpressure from terminal failure.
+    FeedResult feed_packet(const uint8_t *data, size_t size, int64_t pts);
 
-    // Try to get a decoded frame. Returns true if frame available.
+    // Pops one callback-produced frame. This is a single-consumer interface;
+    // timeout_us may be zero for a non-blocking drain.
     bool dequeue_frame(NativeDecodedFrame &out_frame, int64_t timeout_us = 5000);
 
-    // Release a frame after Vulkan import. Call AImage_delete internally.
+    // Releases both the acquired ImageReader slot and the explicit AHB ref.
     void release_frame(NativeDecodedFrame &frame);
 
     // Stable IDs are available on Android API 31+ and enable import caching.
@@ -43,21 +59,61 @@ public:
     void take_removed_buffer_ids(std::vector<uint64_t> &out_ids);
 
     bool is_initialized() const { return codec_ != nullptr; }
+    bool has_error() const { return async_error_.load() != AMEDIA_OK; }
 
 private:
+    struct OutputEvent {
+        size_t index = 0;
+        AMediaCodecBufferInfo info{};
+        int width = 0;
+        int height = 0;
+        bool rendered = false;
+    };
+
+    static void _on_async_input_available(AMediaCodec *codec, void *userdata,
+                                          int32_t index);
+    static void _on_async_output_available(AMediaCodec *codec, void *userdata,
+                                           int32_t index,
+                                           AMediaCodecBufferInfo *info);
+    static void _on_async_format_changed(AMediaCodec *codec, void *userdata,
+                                         AMediaFormat *format);
+    static void _on_async_error(AMediaCodec *codec, void *userdata,
+                                media_status_t error, int32_t action_code,
+                                const char *detail);
+    static void _on_image_available(void *context, AImageReader *reader);
     static void _on_buffer_removed(void *context, AImageReader *reader,
                                    AHardwareBuffer *buffer);
+
+    void _notify_event();
+    void _release_frame_resources(NativeDecodedFrame &frame);
+    void _reset_event_state();
 
     AMediaCodec *codec_ = nullptr;
     AImageReader *reader_ = nullptr;
     ANativeWindow *window_ = nullptr;
-    int width_ = 0, height_ = 0;
+    std::atomic<int> width_{0};
+    std::atomic<int> height_{0};
     std::atomic<bool> started_{false};
     std::atomic<bool> eos_{false};
     std::atomic<bool> buffer_cache_supported_{false};
+
+    // Serializes callback bodies, including the lightweight wakeup notifier,
+    // with listener teardown so shutdown cannot return during a callback.
+    std::mutex callback_mutex_;
+
+    std::mutex event_mutex_;
+    std::condition_variable event_cv_;
+    std::deque<size_t> available_input_indices_;
+    std::deque<OutputEvent> available_output_events_;
+    OutputEvent pending_output_{};
+    bool pending_output_valid_ = false;
+    uint64_t image_event_generation_ = 0;
+    bool stopping_ = true;
+    std::atomic<media_status_t> async_error_{AMEDIA_OK};
+    EventNotifier event_notifier_;
+
     std::mutex removed_buffers_mutex_;
     std::vector<uint64_t> removed_buffer_ids_;
-    int64_t input_pts_counter_ = 0;
 };
 
 } // namespace godot

--- a/addons/nightfall-stream/src/video/stream_connection.cpp
+++ b/addons/nightfall-stream/src/video/stream_connection.cpp
@@ -35,6 +35,7 @@ AHardwareBuffer *mediacodec_get_ahb(jobject media_codec_obj, ssize_t buffer_inde
 
 #include <algorithm>
 #include <cstring>
+#include <utility>
 
 extern "C" {
 #include <libavutil/pixdesc.h>
@@ -90,12 +91,9 @@ StreamConnection::~StreamConnection() {
         if (dummy_sampler_.is_valid()) rd->free_rid(dummy_sampler_);
         if (rgba_output_tex_.is_valid()) rd->free_rid(rgba_output_tex_);
     }
-    // Safe to shutdown now — decode thread is joined by stop()
-    auto *old_codec = native_codec_.exchange(nullptr);
-    if (old_codec) {
-        old_codec->shutdown();
-        delete old_codec;
-    }
+    // Safe to retire now — decode thread is joined by stop(). The codec shuts
+    // down when the last decode-thread reference is released.
+    _replace_native_codec(nullptr);
 #endif
     if (h264_extradata_) {
         av_freep(&h264_extradata_);
@@ -104,6 +102,22 @@ StreamConnection::~StreamConnection() {
 }
 
 #ifdef __ANDROID__
+std::shared_ptr<AndroidMediaCodec> StreamConnection::_get_native_codec() const {
+    std::lock_guard<std::mutex> lock(native_codec_mutex_);
+    return native_codec_;
+}
+
+void StreamConnection::_replace_native_codec(
+        std::shared_ptr<AndroidMediaCodec> replacement) {
+    std::shared_ptr<AndroidMediaCodec> retired;
+    {
+        std::lock_guard<std::mutex> lock(native_codec_mutex_);
+        retired = std::exchange(native_codec_, std::move(replacement));
+    }
+    // Destruction occurs outside the publication lock. If the decode thread
+    // still owns the old codec, its shutdown is naturally deferred.
+}
+
 void StreamConnection::_ensure_compute_pipeline(RenderingDevice *rd, int width, int height,
                                                 uint64_t generation) {
     std::lock_guard<std::mutex> state_lock(render_state_mutex_);
@@ -621,17 +635,11 @@ int StreamConnection::_cb_decoder_setup(int videoFormat, int width, int height, 
     // Android: ONLY native NDK MediaCodec + ImageReader for zero-copy GPU decode.
     // No FFmpeg fallback. Must fail loudly if unavailable.
 
-    // Prevent new decode work from entering this render generation. The old
-    // codec is intentionally not destroyed here because a decode call may still
-    // hold the raw pointer (pre-existing lifecycle behavior).
+    // Prevent new decode work from entering this render generation. A decode
+    // iteration keeps a shared reference, so replacement cannot destroy a codec
+    // while feed/dequeue operations are still using it.
     self->decoder_ready_.store(false);
-    auto *old_codec = self->native_codec_.exchange(nullptr);
-    if (old_codec) {
-        // Can't safely shutdown or delete here — decode thread may be using it.
-        // Store in a to-be-cleaned-up list or just leak until full stop.
-        // The decode thread loads the atomic pointer fresh each iteration,
-        // so it will switch to the new codec on the next loop.
-    }
+    self->_replace_native_codec(nullptr);
 
     // Start a new render generation before retiring cached imports. The state
     // lock serializes invalidation with pipeline creation and command recording.
@@ -667,10 +675,20 @@ int StreamConnection::_cb_decoder_setup(int videoFormat, int width, int height, 
         mime = "video/avc";
     }
     if (mime) {
-        auto *new_codec = new AndroidMediaCodec();
-        if (new_codec->init(mime, width, height)) {
+        auto new_codec = std::make_shared<AndroidMediaCodec>();
+        auto notify_decode_thread = [self] {
+            {
+                // Condition-variable predicate mutations use the same mutex as
+                // the waiter so a callback cannot notify between its predicate
+                // check and sleep transition.
+                std::lock_guard<std::mutex> lock(self->queue_mutex_);
+                self->native_codec_event_.store(true);
+            }
+            self->queue_cv_.notify_one();
+        };
+        if (new_codec->init(mime, width, height, notify_decode_thread)) {
             NF_LOG("StreamConnection", "Native MediaCodec created: %dx%d mime=%s", width, height, mime);
-            self->native_codec_.store(new_codec);
+            self->_replace_native_codec(new_codec);
             self->native_video_width_ = width;
             self->native_video_height_ = height;
             // Only ensure shader material exists (no texture setup — compute pipeline handles it)
@@ -680,7 +698,6 @@ int StreamConnection::_cb_decoder_setup(int videoFormat, int width, int height, 
             return 0;
         }
         NF_LOGE("StreamConnection", "FATAL: Native MediaCodec init failed for %s", mime);
-        delete new_codec;
         return -1;
     }
     NF_LOGE("StreamConnection", "FATAL: Unsupported video format 0x%x on Android", videoFormat);
@@ -736,7 +753,7 @@ void StreamConnection::_cb_decoder_cleanup() {
     // Invalidate render state before uploader cleanup so no queued dispatch can
     // pass its generation guard and then touch an uploader being torn down.
     self->decoder_ready_.store(false);
-    self->native_codec_.exchange(nullptr);
+    self->_replace_native_codec(nullptr);
 
     RenderingServer *rs = RenderingServer::get_singleton();
     RenderingDevice *rd = rs ? rs->get_rendering_device() : nullptr;
@@ -1060,6 +1077,9 @@ void StreamConnection::_connection_thread_func() {
 
 void StreamConnection::_decode_thread_func() {
     AVPacket *pkt = nullptr;
+#ifdef __ANDROID__
+    bool native_input_blocked = false;
+#endif
 
     {
         std::unique_lock<std::mutex> lock(queue_mutex_);
@@ -1070,25 +1090,42 @@ void StreamConnection::_decode_thread_func() {
     }
 
     while (true) {
+        pkt = nullptr;
         {
             std::unique_lock<std::mutex> lock(queue_mutex_);
-            queue_cv_.wait(lock, [this] {
+            queue_cv_.wait(lock, [this
+#ifdef __ANDROID__
+                                  , &native_input_blocked
+#endif
+            ] {
+#ifdef __ANDROID__
+                return (!packet_queue_.empty() && !native_input_blocked) ||
+                       native_codec_event_.load() || !is_streaming_.load();
+#else
                 return !packet_queue_.empty() || !is_streaming_.load();
+#endif
             });
 
-            if (!is_streaming_.load() && packet_queue_.empty()) break;
+            if (!is_streaming_.load()) break;
 
-            if (packet_queue_.empty()) continue;
-
-            pkt = packet_queue_.front();
-            packet_queue_.erase(packet_queue_.begin());
+#ifdef __ANDROID__
+            if (native_codec_event_.exchange(false)) {
+                native_input_blocked = false;
+            }
+#endif
+            if (!packet_queue_.empty()
+#ifdef __ANDROID__
+                && !native_input_blocked
+#endif
+            ) {
+                pkt = packet_queue_.front();
+                packet_queue_.erase(packet_queue_.begin());
+            }
         }
-
-        if (!pkt) continue;
 
 #ifdef __ANDROID__
         uint64_t decode_generation = render_generation_.load();
-        AndroidMediaCodec *codec = native_codec_.load();
+        std::shared_ptr<AndroidMediaCodec> codec = _get_native_codec();
         if (codec && decoder_ready_.load()) {
             std::vector<uint64_t> removed_buffer_ids;
             codec->take_removed_buffer_ids(removed_buffer_ids);
@@ -1099,14 +1136,44 @@ void StreamConnection::_decode_thread_func() {
                 }
             }
 
-            // Native MediaCodec path: feed raw packet data, get AHB frames
-            int send_ret = codec->feed_packet(pkt->data, (size_t)pkt->size, pkt->pts);
-            av_packet_free(&pkt);
-            if (!send_ret) continue;
+            // Feed input when present, but drain callback-produced output even
+            // when input backpressure temporarily leaves no buffer available.
+            if (pkt) {
+                AndroidMediaCodec::FeedResult feed_result;
+                bool stale_codec = false;
+                {
+                    // Keep publication stable across the non-blocking queue
+                    // operation so a packet cannot enter a retired generation.
+                    std::lock_guard<std::mutex> codec_lock(native_codec_mutex_);
+                    stale_codec = native_codec_ != codec || !decoder_ready_.load() ||
+                                  decode_generation != render_generation_.load();
+                    feed_result = stale_codec
+                        ? AndroidMediaCodec::FeedResult::BACKPRESSURE
+                        : codec->feed_packet(pkt->data, (size_t)pkt->size, pkt->pts);
+                }
 
-            // Try to dequeue frames
+                if (feed_result == AndroidMediaCodec::FeedResult::QUEUED) {
+                    native_input_blocked = false;
+                    av_packet_free(&pkt);
+                } else if (feed_result == AndroidMediaCodec::FeedResult::BACKPRESSURE) {
+                    native_input_blocked = !stale_codec;
+                    std::lock_guard<std::mutex> lock(queue_mutex_);
+                    packet_queue_.insert(packet_queue_.begin(), pkt);
+                    pkt = nullptr;
+                } else {
+                    NF_LOGE("StreamConnection", "Native MediaCodec input failed; terminating stream");
+                    decoder_ready_.store(false);
+                    is_streaming_.store(false);
+                    av_packet_free(&pkt);
+                    queue_cv_.notify_all();
+                    LiInterruptConnection();
+                }
+            }
+
+            // Output indices and image availability arrive via callbacks. A
+            // zero timeout drains all work already ready without stalling input.
             NativeDecodedFrame frame;
-            while (codec->dequeue_frame(frame, 1000)) {
+            while (codec->dequeue_frame(frame, 0)) {
                 RenderingDevice *rd = RenderingServer::get_singleton()
                     ? RenderingServer::get_singleton()->get_rendering_device() : nullptr;
 
@@ -1236,9 +1303,18 @@ void StreamConnection::_decode_thread_func() {
 
                 codec->release_frame(frame);
             }
+            if (codec->has_error()) {
+                NF_LOGE("StreamConnection", "Native MediaCodec reported an asynchronous error; terminating stream");
+                decoder_ready_.store(false);
+                is_streaming_.store(false);
+                queue_cv_.notify_all();
+                LiInterruptConnection();
+            }
             continue; // Skip FFmpeg path
         }
 #endif
+
+        if (!pkt) continue;
 
         if (decoder_->is_raw_decode()) {
             if (pkt->size >= (int)sizeof(RawFrameHeader)) {
@@ -1486,6 +1562,11 @@ void StreamConnection::start(const String &host, const Dictionary &server_info, 
         decode_thread_.join();
     }
 
+#ifdef __ANDROID__
+    _replace_native_codec(nullptr);
+    native_codec_event_.store(false);
+#endif
+
     {
         std::lock_guard<std::mutex> lock(queue_mutex_);
         _clear_packet_queue();
@@ -1572,6 +1653,12 @@ void StreamConnection::stop() {
     if (decode_thread_.joinable()) {
         decode_thread_.join();
     }
+
+#ifdef __ANDROID__
+    // No callback may retain the StreamConnection wakeup after stop returns.
+    _replace_native_codec(nullptr);
+    native_codec_event_.store(false);
+#endif
 
     {
         std::lock_guard<std::mutex> lock(queue_mutex_);
@@ -1696,7 +1783,7 @@ int StreamConnection::get_video_height() const {
 
 bool StreamConnection::is_hw_decode() const {
 #ifdef __ANDROID__
-    if (native_codec_) return true; // Native MediaCodec is always HW
+    if (_get_native_codec()) return true; // Native MediaCodec is always HW
 #endif
     if (decoder_.is_valid()) return decoder_->is_hw_decode();
     return false;

--- a/addons/nightfall-stream/src/video/stream_connection.cpp
+++ b/addons/nightfall-stream/src/video/stream_connection.cpp
@@ -33,6 +33,7 @@ AHardwareBuffer *mediacodec_get_ahb(jobject media_codec_obj, ssize_t buffer_inde
 #include <godot_cpp/variant/dictionary.hpp>
 #include <godot_cpp/variant/packed_byte_array.hpp>
 
+#include <algorithm>
 #include <cstring>
 
 extern "C" {
@@ -66,11 +67,13 @@ StreamConnection::StreamConnection() {
     native_video_height_ = 0;
     native_color_range_ = 0;
     native_color_matrix_type_ = 0;
-    pending_ahb_ptr_ = 0;
+    pending_buffer_id_ = 0;
+    pending_generation_ = 0;
+    pending_uncached_buffer_ptr_ = 0;
     pending_width_ = 0;
     pending_height_ = 0;
-    pending_color_range_ = 0;
-    pending_color_matrix_type_ = 0;
+    pending_dispatch_cached_ = false;
+    pending_dispatch_ready_ = false;
 #endif
 }
 
@@ -79,7 +82,9 @@ StreamConnection::~StreamConnection() {
 #ifdef __ANDROID__
     RenderingDevice *rd = RenderingServer::get_singleton()
         ? RenderingServer::get_singleton()->get_rendering_device() : nullptr;
+    _retire_all_ahb_imports();
     if (rd) {
+        _render_free_pipeline_rt();
         if (compute_pipeline_.is_valid()) rd->free_rid(compute_pipeline_);
         if (compute_shader_.is_valid()) rd->free_rid(compute_shader_);
         if (dummy_sampler_.is_valid()) rd->free_rid(dummy_sampler_);
@@ -99,7 +104,11 @@ StreamConnection::~StreamConnection() {
 }
 
 #ifdef __ANDROID__
-void StreamConnection::_ensure_compute_pipeline(RenderingDevice *rd, int width, int height) {
+void StreamConnection::_ensure_compute_pipeline(RenderingDevice *rd, int width, int height,
+                                                uint64_t generation) {
+    std::lock_guard<std::mutex> state_lock(render_state_mutex_);
+    if (generation != render_generation_.load()) return;
+
     static int ep_log = 0;
     if (++ep_log <= 3) __android_log_print(ANDROID_LOG_INFO, "STRDEBG", "_ensure_compute_pipeline: ready=%d rd=%p w=%d h=%d",
         (int)compute_pipeline_ready_, (void*)rd, width, height);
@@ -161,47 +170,209 @@ void StreamConnection::_ensure_compute_pipeline(RenderingDevice *rd, int width, 
     __android_log_print(ANDROID_LOG_INFO, "STRDEBG", "Compute pipeline ready! %dx%d", width, height);
 }
 
-void StreamConnection::_render_compute_dispatch(RID ycbcr_tex_rid, RID ycbcr_sampler_rid, uint64_t ahb_ptr, int width, int height) {
-    // Used for direct call from render thread (non-queued path, kept for reference)
+bool StreamConnection::_get_or_create_ahb_import(RenderingDevice *rd,
+        uint64_t buffer_ptr, uint64_t buffer_id, int width, int height,
+        uint64_t generation) {
+    std::lock_guard<std::mutex> lock(ahb_cache_mutex_);
+    if (generation != render_generation_.load() || !compute_pipeline_ready_) return false;
+
+    auto existing = std::find_if(ahb_import_cache_.begin(), ahb_import_cache_.end(),
+        [buffer_id, generation](const CachedAhbImport &entry) {
+            return entry.buffer_id == buffer_id && entry.generation == generation;
+        });
+    if (existing != ahb_import_cache_.end()) {
+        ahb_cache_hits_++;
+        return true;
+    }
+
+    int usage = (int)RenderingDevice::TEXTURE_USAGE_SAMPLING_BIT;
+    Variant texture_var = rd->call("texture_create_from_android_hardware_buffer",
+        buffer_ptr, (int)RenderingDevice::DATA_FORMAT_R8G8B8A8_UNORM,
+        width, height, usage);
+    RID texture = texture_var;
+    if (!texture.is_valid()) return false;
+
+    Variant sampler_var = rd->call("texture_get_ycbcr_sampler", texture);
+    RID sampler = sampler_var;
+    if (!sampler.is_valid()) {
+        rd->free_rid(texture);
+        return false;
+    }
+
+    // Reconfiguration may have started while the driver import was executing.
+    if (generation != render_generation_.load() || !compute_pipeline_ready_) {
+        rd->free_rid(sampler);
+        rd->free_rid(texture);
+        return false;
+    }
+
+    CachedAhbImport entry;
+    entry.buffer_id = buffer_id;
+    entry.generation = generation;
+    entry.texture = texture;
+    entry.sampler = sampler;
+    // Keep the opaque handle and pointer fallback key valid until the imported
+    // Vulkan objects are retired, independent of the frame's AImage lifetime.
+    AHardwareBuffer_acquire((AHardwareBuffer *)buffer_ptr);
+    entry.owned_buffer_ptr = buffer_ptr;
+    ahb_import_cache_.push_back(entry);
+    ahb_cache_misses_++;
+
+    NF_LOG("StreamConnection", "AHB import cache miss: id=%llu entries=%zu hits=%llu misses=%llu",
+           (unsigned long long)buffer_id, ahb_import_cache_.size(),
+           (unsigned long long)ahb_cache_hits_, (unsigned long long)ahb_cache_misses_);
+    return true;
+}
+
+bool StreamConnection::_retire_removed_ahb_imports(const std::vector<uint64_t> &buffer_ids) {
+    if (buffer_ids.empty()) return false;
+
+    bool retired = false;
+    {
+        std::lock_guard<std::mutex> lock(ahb_cache_mutex_);
+        auto it = ahb_import_cache_.begin();
+        while (it != ahb_import_cache_.end()) {
+            if (std::find(buffer_ids.begin(), buffer_ids.end(), it->buffer_id) != buffer_ids.end()) {
+                pending_free_ahb_imports_.push_back(*it);
+                it = ahb_import_cache_.erase(it);
+                retired = true;
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    if (retired) {
+        std::lock_guard<std::mutex> lock(pending_mutex_);
+        if (pending_dispatch_cached_ &&
+            std::find(buffer_ids.begin(), buffer_ids.end(), pending_buffer_id_) != buffer_ids.end()) {
+            pending_dispatch_ready_ = false;
+        }
+    }
+    return retired;
+}
+
+bool StreamConnection::_retire_all_ahb_imports() {
+    bool retired = false;
+    {
+        std::lock_guard<std::mutex> lock(ahb_cache_mutex_);
+        retired = !ahb_import_cache_.empty();
+        pending_free_ahb_imports_.insert(pending_free_ahb_imports_.end(),
+                                         ahb_import_cache_.begin(), ahb_import_cache_.end());
+        ahb_import_cache_.clear();
+        if (retired) {
+            NF_LOG("StreamConnection", "Retiring AHB import cache: hits=%llu misses=%llu",
+                   (unsigned long long)ahb_cache_hits_,
+                   (unsigned long long)ahb_cache_misses_);
+        }
+        ahb_cache_hits_ = 0;
+        ahb_cache_misses_ = 0;
+    }
+
+    CachedAhbImport pending_uncached;
+    bool retire_pending_uncached = false;
+    {
+        std::lock_guard<std::mutex> lock(pending_mutex_);
+        if (pending_dispatch_ready_ && !pending_dispatch_cached_) {
+            pending_uncached.generation = pending_generation_;
+            pending_uncached.texture = pending_uncached_texture_;
+            pending_uncached.sampler = pending_uncached_sampler_;
+            pending_uncached.owned_buffer_ptr = pending_uncached_buffer_ptr_;
+            retire_pending_uncached = true;
+        }
+        pending_dispatch_ready_ = false;
+        pending_dispatch_cached_ = false;
+        pending_uncached_texture_ = RID();
+        pending_uncached_sampler_ = RID();
+        pending_uncached_buffer_ptr_ = 0;
+    }
+    if (retire_pending_uncached) {
+        std::lock_guard<std::mutex> lock(ahb_cache_mutex_);
+        pending_free_ahb_imports_.push_back(pending_uncached);
+        retired = true;
+    }
+    return retired;
 }
 
 void StreamConnection::_render_compute_dispatch_rt() {
     static int rt_enter = 0;
     if (++rt_enter == 1) __android_log_print(ANDROID_LOG_INFO, "STRDEBG", "RT_ENTER");
-    // Read pending dispatch data
-    RID ycbcr_tex_rid, ycbcr_sampler_rid;
-    uint64_t ahb_ptr;
-    int width, height;
+
+    uint64_t buffer_id = 0;
+    uint64_t generation = 0;
+    RID uncached_texture;
+    RID uncached_sampler;
+    uint64_t uncached_buffer_ptr = 0;
+    int width = 0;
+    int height = 0;
+    bool cached_dispatch = false;
     {
         std::lock_guard<std::mutex> lock(pending_mutex_);
-        ycbcr_tex_rid = pending_ycbcr_tex_rid_;
-        ycbcr_sampler_rid = pending_ycbcr_sampler_rid_;
-        ahb_ptr = pending_ahb_ptr_;
+        if (!pending_dispatch_ready_) return;
+        buffer_id = pending_buffer_id_;
+        generation = pending_generation_;
+        uncached_texture = pending_uncached_texture_;
+        uncached_sampler = pending_uncached_sampler_;
+        uncached_buffer_ptr = pending_uncached_buffer_ptr_;
         width = pending_width_;
         height = pending_height_;
-        pending_ahb_ptr_ = 0;
+        cached_dispatch = pending_dispatch_cached_;
+        pending_dispatch_ready_ = false;
+        pending_uncached_texture_ = RID();
+        pending_uncached_sampler_ = RID();
+        pending_uncached_buffer_ptr_ = 0;
     }
-
-    if (ahb_ptr == 0) return;
 
     RenderingDevice *rd = RenderingServer::get_singleton()
         ? RenderingServer::get_singleton()->get_rendering_device() : nullptr;
-    if (!rd || !compute_pipeline_ready_) {
-        if (ycbcr_sampler_rid.is_valid() && rd) rd->free_rid(ycbcr_sampler_rid);
-        if (ycbcr_tex_rid.is_valid() && rd) rd->free_rid(ycbcr_tex_rid);
-        AHardwareBuffer_release((AHardwareBuffer *)ahb_ptr);
+    auto release_uncached = [&]() {
+        if (cached_dispatch) return;
+        if (rd && uncached_sampler.is_valid()) rd->free_rid(uncached_sampler);
+        if (rd && uncached_texture.is_valid()) rd->free_rid(uncached_texture);
+        if (uncached_buffer_ptr != 0) {
+            AHardwareBuffer_release((AHardwareBuffer *)uncached_buffer_ptr);
+            uncached_buffer_ptr = 0;
+        }
+    };
+    if (!rd) {
+        release_uncached();
         return;
     }
 
-    // Dispatch compute shader FIRST (so rgba_output_tex_ has valid data before display)
-    {
-        // Build uniform set
+    // Keep reconfiguration from moving pipeline/output RIDs while this command
+    // is being recorded. Cache retirement itself is queued after this callback.
+    std::lock_guard<std::mutex> state_lock(render_state_mutex_);
+    if (!compute_pipeline_ready_ || generation != render_generation_.load()) {
+        release_uncached();
+        return;
+    }
+
+    RID texture;
+    RID sampler;
+    RID uniform_set;
+    bool uniform_set_owned = !cached_dispatch;
+    if (cached_dispatch) {
+        std::lock_guard<std::mutex> lock(ahb_cache_mutex_);
+        auto entry = std::find_if(ahb_import_cache_.begin(), ahb_import_cache_.end(),
+            [buffer_id, generation](const CachedAhbImport &cached) {
+                return cached.buffer_id == buffer_id && cached.generation == generation;
+            });
+        if (entry == ahb_import_cache_.end()) return;
+        texture = entry->texture;
+        sampler = entry->sampler;
+        uniform_set = entry->uniform_set;
+    } else {
+        texture = uncached_texture;
+        sampler = uncached_sampler;
+    }
+
+    if (!uniform_set.is_valid()) {
         Ref<RDUniform> u_sampler;
         u_sampler.instantiate();
         u_sampler->set_uniform_type(RenderingDevice::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE);
         u_sampler->set_binding(0);
-        u_sampler->add_id(ycbcr_sampler_rid);
-        u_sampler->add_id(ycbcr_tex_rid);
+        u_sampler->add_id(sampler);
+        u_sampler->add_id(texture);
 
         Ref<RDUniform> u_output;
         u_output.instantiate();
@@ -212,15 +383,29 @@ void StreamConnection::_render_compute_dispatch_rt() {
         TypedArray<RDUniform> uniforms;
         uniforms.append(u_sampler);
         uniforms.append(u_output);
-
-        RID uniform_set = rd->uniform_set_create(uniforms, compute_shader_, 0);
-        if (!uniform_set.is_valid()) {
-            rd->free_rid(ycbcr_sampler_rid);
-            rd->free_rid(ycbcr_tex_rid);
-            AHardwareBuffer_release((AHardwareBuffer *)ahb_ptr);
-            return;
+        uniform_set = rd->uniform_set_create(uniforms, compute_shader_, 0);
+        if (cached_dispatch && uniform_set.is_valid()) {
+            std::lock_guard<std::mutex> lock(ahb_cache_mutex_);
+            auto entry = std::find_if(ahb_import_cache_.begin(), ahb_import_cache_.end(),
+                [buffer_id, generation](const CachedAhbImport &cached) {
+                    return cached.buffer_id == buffer_id && cached.generation == generation;
+                });
+            if (entry != ahb_import_cache_.end()) {
+                entry->uniform_set = uniform_set;
+            } else {
+                // A buffer-removed callback retired the entry while the uniform
+                // was being built. Keep this set local to the current dispatch.
+                uniform_set_owned = true;
+            }
         }
+    }
+    if (!uniform_set.is_valid()) {
+        release_uncached();
+        return;
+    }
 
+    // Dispatch compute shader FIRST (so rgba_output_tex_ has valid data before display)
+    {
         int64_t cmd = rd->compute_list_begin();
         rd->compute_list_bind_compute_pipeline(cmd, compute_pipeline_);
         rd->compute_list_bind_uniform_set(cmd, uniform_set, 0);
@@ -249,8 +434,6 @@ void StreamConnection::_render_compute_dispatch_rt() {
 
         rd->compute_list_dispatch(cmd, (width + 15) / 16, (height + 15) / 16, 1);
         rd->compute_list_end();
-
-        rd->free_rid(uniform_set);
     }
 
     // One-time per session AFTER first compute dispatch: wire display to rgba_output_tex_
@@ -274,11 +457,9 @@ void StreamConnection::_render_compute_dispatch_rt() {
         }
     }
 
-    // Cleanup
-    rd->free_rid(ycbcr_sampler_rid);
-    rd->free_rid(ycbcr_tex_rid);
+    if (uniform_set_owned) rd->free_rid(uniform_set);
+    if (!cached_dispatch) release_uncached();
 
-    AHardwareBuffer_release((AHardwareBuffer *)ahb_ptr);
     static int rt_done = 0;
     if (++rt_done <= 3) __android_log_print(ANDROID_LOG_INFO, "STRDEBG", "RT: dispatch complete");
 }
@@ -287,6 +468,20 @@ void StreamConnection::_render_free_pipeline_rt() {
     RenderingDevice *rd = RenderingServer::get_singleton()
         ? RenderingServer::get_singleton()->get_rendering_device() : nullptr;
     if (!rd) return;
+
+    std::vector<CachedAhbImport> retired_imports;
+    {
+        std::lock_guard<std::mutex> lock(ahb_cache_mutex_);
+        retired_imports.swap(pending_free_ahb_imports_);
+    }
+    for (const CachedAhbImport &entry : retired_imports) {
+        if (entry.uniform_set.is_valid()) rd->free_rid(entry.uniform_set);
+        if (entry.sampler.is_valid()) rd->free_rid(entry.sampler);
+        if (entry.texture.is_valid()) rd->free_rid(entry.texture);
+        if (entry.owned_buffer_ptr != 0) {
+            AHardwareBuffer_release((AHardwareBuffer *)entry.owned_buffer_ptr);
+        }
+    }
 
     if (pending_free_pipeline_.is_valid()) { rd->free_rid(pending_free_pipeline_); pending_free_pipeline_ = RID(); }
     if (pending_free_shader_.is_valid()) { rd->free_rid(pending_free_shader_); pending_free_shader_ = RID(); }
@@ -426,10 +621,10 @@ int StreamConnection::_cb_decoder_setup(int videoFormat, int width, int height, 
     // Android: ONLY native NDK MediaCodec + ImageReader for zero-copy GPU decode.
     // No FFmpeg fallback. Must fail loudly if unavailable.
 
-    // Shut down any existing codec before reconfiguration
-    // IMPORTANT: don't call shutdown() here — the decode thread may still be
-    // inside a dequeue_frame() call. Just swap the pointer atomically.
-    // Old codecs will be cleaned up in _cb_decoder_cleanup via exchange+shutdown.
+    // Prevent new decode work from entering this render generation. The old
+    // codec is intentionally not destroyed here because a decode call may still
+    // hold the raw pointer (pre-existing lifecycle behavior).
+    self->decoder_ready_.store(false);
     auto *old_codec = self->native_codec_.exchange(nullptr);
     if (old_codec) {
         // Can't safely shutdown or delete here — decode thread may be using it.
@@ -438,24 +633,30 @@ int StreamConnection::_cb_decoder_setup(int videoFormat, int width, int height, 
         // so it will switch to the new codec on the next loop.
     }
 
-    // Reset compute pipeline state for reconfiguration
-    // IMPORTANT: set compute_pipeline_ready_ = false FIRST so queued render-thread
-    // callbacks will bail out before using resources we're about to free.
-    self->compute_pipeline_ready_ = false;
-    self->display_wired_ = false;
-
-    // Free GPU resources on render thread to guarantee no pending callbacks use them
+    // Start a new render generation before retiring cached imports. The state
+    // lock serializes invalidation with pipeline creation and command recording.
     RenderingServer *rs = RenderingServer::get_singleton();
     RenderingDevice *rd = rs ? rs->get_rendering_device() : nullptr;
+    {
+        std::lock_guard<std::mutex> state_lock(self->render_state_mutex_);
+        self->compute_pipeline_ready_ = false;
+        self->display_wired_ = false;
+        self->render_generation_.fetch_add(1);
+        if (rd) {
+            self->pending_free_pipeline_ = self->compute_pipeline_;
+            self->pending_free_shader_ = self->compute_shader_;
+            self->pending_free_sampler_ = self->dummy_sampler_;
+            self->pending_free_tex_ = self->rgba_output_tex_;
+            self->compute_pipeline_ = RID();
+            self->compute_shader_ = RID();
+            self->dummy_sampler_ = RID();
+            self->rgba_output_tex_ = RID();
+        }
+    }
+    self->_retire_all_ahb_imports();
+
+    // Free old-generation GPU resources after previously queued dispatches.
     if (rd) {
-        self->pending_free_pipeline_ = self->compute_pipeline_;
-        self->pending_free_shader_ = self->compute_shader_;
-        self->pending_free_sampler_ = self->dummy_sampler_;
-        self->pending_free_tex_ = self->rgba_output_tex_;
-        self->compute_pipeline_ = RID();
-        self->compute_shader_ = RID();
-        self->dummy_sampler_ = RID();
-        self->rgba_output_tex_ = RID();
         rs->call_on_render_thread(callable_mp(self, &StreamConnection::_render_free_pipeline_rt));
     }
 
@@ -529,33 +730,52 @@ void StreamConnection::_cb_decoder_stop() {
 void StreamConnection::_cb_decoder_cleanup() {
     NF_LOG("StreamConnection", "Decoder cleanup");
     auto *self = active_instance_;
-    if (self) {
-        if (!self->local_capture_mode_) {
-            self->decoder_->cleanup();
-            self->uploader_->cleanup();
-        }
+    if (!self) return;
+
 #ifdef __ANDROID__
-        // Just swap pointer — don't shutdown while decode thread may be active.
-        // Final cleanup happens in destructor after decode thread is joined.
-        self->native_codec_.exchange(nullptr);
-        // Free compute pipeline resources
-        RenderingDevice *rd = RenderingServer::get_singleton()
-            ? RenderingServer::get_singleton()->get_rendering_device() : nullptr;
-        if (rd) {
-            if (self->compute_pipeline_.is_valid()) rd->free_rid(self->compute_pipeline_);
-            if (self->compute_shader_.is_valid()) rd->free_rid(self->compute_shader_);
-            if (self->dummy_sampler_.is_valid()) rd->free_rid(self->dummy_sampler_);
-            if (self->rgba_output_tex_.is_valid()) rd->free_rid(self->rgba_output_tex_);
-        }
+    // Invalidate render state before uploader cleanup so no queued dispatch can
+    // pass its generation guard and then touch an uploader being torn down.
+    self->decoder_ready_.store(false);
+    self->native_codec_.exchange(nullptr);
+
+    RenderingServer *rs = RenderingServer::get_singleton();
+    RenderingDevice *rd = rs ? rs->get_rendering_device() : nullptr;
+    {
+        std::lock_guard<std::mutex> state_lock(self->render_state_mutex_);
         self->compute_pipeline_ready_ = false;
-#endif
-        self->decoder_ready_.store(false);
-        self->h264_hw_upgrade_pending_.store(false);
-        self->h264_hw_upgraded_.store(false);
-        if (self->h264_extradata_) {
-            av_freep(&self->h264_extradata_);
-            self->h264_extradata_size_ = 0;
+        self->render_generation_.fetch_add(1);
+        if (rd) {
+            self->pending_free_pipeline_ = self->compute_pipeline_;
+            self->pending_free_shader_ = self->compute_shader_;
+            self->pending_free_sampler_ = self->dummy_sampler_;
+            self->pending_free_tex_ = self->rgba_output_tex_;
+            self->compute_pipeline_ = RID();
+            self->compute_shader_ = RID();
+            self->dummy_sampler_ = RID();
+            self->rgba_output_tex_ = RID();
         }
+    }
+    self->_retire_all_ahb_imports();
+#endif
+
+    if (!self->local_capture_mode_) {
+        self->decoder_->cleanup();
+        self->uploader_->cleanup();
+    }
+
+#ifdef __ANDROID__
+    // Cleanup may be followed immediately by destruction. Avoid adding a new
+    // member callback that could outlive StreamConnection; the original path
+    // also released these resources synchronously here.
+    if (rd) self->_render_free_pipeline_rt();
+#endif
+
+    self->decoder_ready_.store(false);
+    self->h264_hw_upgrade_pending_.store(false);
+    self->h264_hw_upgraded_.store(false);
+    if (self->h264_extradata_) {
+        av_freep(&self->h264_extradata_);
+        self->h264_extradata_size_ = 0;
     }
 }
 
@@ -867,8 +1087,18 @@ void StreamConnection::_decode_thread_func() {
         if (!pkt) continue;
 
 #ifdef __ANDROID__
+        uint64_t decode_generation = render_generation_.load();
         AndroidMediaCodec *codec = native_codec_.load();
         if (codec && decoder_ready_.load()) {
+            std::vector<uint64_t> removed_buffer_ids;
+            codec->take_removed_buffer_ids(removed_buffer_ids);
+            if (_retire_removed_ahb_imports(removed_buffer_ids)) {
+                RenderingServer *rs = RenderingServer::get_singleton();
+                if (rs) {
+                    rs->call_on_render_thread(callable_mp(this, &StreamConnection::_render_free_pipeline_rt));
+                }
+            }
+
             // Native MediaCodec path: feed raw packet data, get AHB frames
             int send_ret = codec->feed_packet(pkt->data, (size_t)pkt->size, pkt->pts);
             av_packet_free(&pkt);
@@ -888,69 +1118,110 @@ void StreamConnection::_decode_thread_func() {
                     continue;
                 }
 
-                // One-time compute pipeline setup
-                _ensure_compute_pipeline(rd, frame.width, frame.height);
-
-                if (!compute_pipeline_ready_) {
+                if (!decoder_ready_.load() || decode_generation != render_generation_.load()) {
                     codec->release_frame(frame);
                     continue;
                 }
 
-                // Import AHB as YCbCr texture (engine patch handles Vulkan image creation + YCbCr conversion)
-                int usage = (int)(RenderingDevice::TEXTURE_USAGE_SAMPLING_BIT);
-                static int tc_log = 0;
-                if (++tc_log <= 3) __android_log_print(ANDROID_LOG_INFO, "STRDEBG", "calling texture_create_from_android_hardware_buffer");
-                Variant tex_rid_var = rd->call("texture_create_from_android_hardware_buffer",
-                    (uint64_t)frame.buffer,
-                    (int)RenderingDevice::DATA_FORMAT_R8G8B8A8_UNORM,
-                    frame.width, frame.height, usage);
-                RID ycbcr_tex_rid = tex_rid_var;
-                static int a_log = 0;
-                if (++a_log <= 1) __android_log_print(ANDROID_LOG_INFO, "STRDEBG", "AHB_OK");
+                // One-time compute pipeline setup for the generation that fed
+                // this frame. Old-codec frames cannot initialize new resources.
+                _ensure_compute_pipeline(rd, frame.width, frame.height, decode_generation);
 
-                if (!ycbcr_tex_rid.is_valid()) {
+                if (!decoder_ready_.load() || !compute_pipeline_ready_ ||
+                    decode_generation != render_generation_.load()) {
                     codec->release_frame(frame);
                     continue;
                 }
 
-                // Get YCbCr sampler for this texture
-                Variant sampler_var = rd->call("texture_get_ycbcr_sampler", ycbcr_tex_rid);
-                RID ycbcr_sampler_rid = sampler_var;
-                static int s_log = 0;
-                if (++s_log <= 3) __android_log_print(ANDROID_LOG_INFO, "STRDEBG", "YCbCr sampler valid=%d", (int)ycbcr_sampler_rid.is_valid());
+                bool cache_enabled = codec->is_import_cache_enabled();
+                uint64_t buffer_id = 0;
+                RID uncached_texture;
+                RID uncached_sampler;
+                uint64_t uncached_buffer_ptr = 0;
 
-                if (!ycbcr_sampler_rid.is_valid()) {
-                    rd->free_rid(ycbcr_tex_rid);
+                if (cache_enabled) {
+                    if (!codec->get_buffer_id(frame.buffer, buffer_id)) {
+                        // API 31 introduced the documented stable ID. The
+                        // buffer-removed listener supplies matching handle keys
+                        // on older Quest OS releases.
+                        buffer_id = (uint64_t)frame.buffer;
+                        static bool warned_pointer_key = false;
+                        if (!warned_pointer_key) {
+                            warned_pointer_key = true;
+                            NF_LOG("StreamConnection", "Using AHardwareBuffer handle cache keys below API 31");
+                        }
+                    }
+
+                    if (!_get_or_create_ahb_import(rd, (uint64_t)frame.buffer,
+                                                   buffer_id, frame.width, frame.height,
+                                                   decode_generation)) {
+                        codec->release_frame(frame);
+                        continue;
+                    }
+                } else {
+                    int usage = (int)RenderingDevice::TEXTURE_USAGE_SAMPLING_BIT;
+                    Variant texture_var = rd->call("texture_create_from_android_hardware_buffer",
+                        (uint64_t)frame.buffer,
+                        (int)RenderingDevice::DATA_FORMAT_R8G8B8A8_UNORM,
+                        frame.width, frame.height, usage);
+                    uncached_texture = texture_var;
+                    if (!uncached_texture.is_valid()) {
+                        codec->release_frame(frame);
+                        continue;
+                    }
+
+                    Variant sampler_var = rd->call("texture_get_ycbcr_sampler", uncached_texture);
+                    uncached_sampler = sampler_var;
+                    if (!uncached_sampler.is_valid()) {
+                        rd->free_rid(uncached_texture);
+                        codec->release_frame(frame);
+                        continue;
+                    }
+
+                    AHardwareBuffer_acquire(frame.buffer);
+                    uncached_buffer_ptr = (uint64_t)frame.buffer;
+                }
+
+                RenderingServer *rs = RenderingServer::get_singleton();
+                if (!rs) {
+                    if (!cache_enabled) {
+                        rd->free_rid(uncached_sampler);
+                        rd->free_rid(uncached_texture);
+                        AHardwareBuffer_release(frame.buffer);
+                    }
                     codec->release_frame(frame);
                     continue;
                 }
 
-                // Acquire AHB reference for render thread
-                AHardwareBuffer_acquire(frame.buffer);
-                static int acq_log = 0;
-                if (++acq_log <= 3) __android_log_print(ANDROID_LOG_INFO, "STRDEBG", "AHB acquired, storing pending dispatch");
-
-                // Store pending dispatch data (RIDs don't cross threads well via call_on_render_thread.bind)
+                RID replaced_texture;
+                RID replaced_sampler;
+                uint64_t replaced_buffer_ptr = 0;
                 {
                     std::lock_guard<std::mutex> lock(pending_mutex_);
-                    pending_ycbcr_tex_rid_ = ycbcr_tex_rid;
-                    pending_ycbcr_sampler_rid_ = ycbcr_sampler_rid;
-                    pending_ahb_ptr_ = (uint64_t)frame.buffer;
+                    if (pending_dispatch_ready_ && !pending_dispatch_cached_) {
+                        replaced_texture = pending_uncached_texture_;
+                        replaced_sampler = pending_uncached_sampler_;
+                        replaced_buffer_ptr = pending_uncached_buffer_ptr_;
+                    }
+                    pending_buffer_id_ = buffer_id;
+                    pending_generation_ = decode_generation;
+                    pending_uncached_texture_ = uncached_texture;
+                    pending_uncached_sampler_ = uncached_sampler;
+                    pending_uncached_buffer_ptr_ = uncached_buffer_ptr;
                     pending_width_ = frame.width;
                     pending_height_ = frame.height;
+                    pending_dispatch_cached_ = cache_enabled;
+                    pending_dispatch_ready_ = true;
+                }
+                if (replaced_sampler.is_valid()) rd->free_rid(replaced_sampler);
+                if (replaced_texture.is_valid()) rd->free_rid(replaced_texture);
+                if (replaced_buffer_ptr != 0) {
+                    AHardwareBuffer_release((AHardwareBuffer *)replaced_buffer_ptr);
                 }
 
-                // Marshal compute dispatch to render thread
-                RenderingServer *rs = RenderingServer::get_singleton();
-                if (rs) {
-                    rs->call_on_render_thread(callable_mp(this, &StreamConnection::_render_compute_dispatch_rt));
-                    static int q_log = 0;
-                    if (++q_log <= 3) __android_log_print(ANDROID_LOG_INFO, "STRDEBG", "CALL queued rt=%d", q_log);
-                } else {
-                    AHardwareBuffer_release(frame.buffer);
-                    rd->free_rid(ycbcr_sampler_rid);
-                    rd->free_rid(ycbcr_tex_rid);
-                }
+                rs->call_on_render_thread(callable_mp(this, &StreamConnection::_render_compute_dispatch_rt));
+                static int q_log = 0;
+                if (++q_log <= 3) __android_log_print(ANDROID_LOG_INFO, "STRDEBG", "CALL queued rt=%d", q_log);
 
                 frames_decoded_.fetch_add(1);
                 static int log_count = 0;

--- a/addons/nightfall-stream/src/video/stream_connection.cpp
+++ b/addons/nightfall-stream/src/video/stream_connection.cpp
@@ -855,23 +855,28 @@ int StreamConnection::_cb_submit_decode_unit(PDECODE_UNIT decodeUnit) {
     auto now_us = std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count();
     self->last_submit_time_us_.store(now_us);
 
+    DecodeUnitQueue::DecodeUnit queued_unit;
+    queued_unit.packet.reset(pkt);
+    queued_unit.is_idr = decodeUnit->frameType == FRAME_TYPE_IDR;
+    queued_unit.frame_number = decodeUnit->frameNumber;
+    queued_unit.presentation_time_us = decodeUnit->presentationTimeUs;
+
+    DecodeUnitQueue::PushResult enqueue_result;
     {
         std::lock_guard<std::mutex> lock(self->queue_mutex_);
-        if (self->packet_queue_.size() > 512) {
-            av_packet_free(&pkt);
-            self->frames_dropped_.fetch_add(1);
-            return DR_OK;
-        }
-        if (!self->decoder_->is_hw_decode() && self->packet_queue_.size() > 128) {
-            self->_clear_packet_queue();
-            LiRequestIdrFrame();
-            av_packet_free(&pkt);
-            self->frames_dropped_.fetch_add(1);
-            return DR_NEED_IDR;
-        }
-        self->packet_queue_.push_back(pkt);
+        enqueue_result = self->packet_queue_.push(std::move(queued_unit));
     }
-    self->queue_cv_.notify_one();
+
+    if (enqueue_result.dropped != 0) {
+        self->frames_dropped_.fetch_add((int)enqueue_result.dropped);
+    }
+    if (enqueue_result.request_idr) {
+        LiRequestIdrFrame();
+        return DR_NEED_IDR;
+    }
+    if (enqueue_result.accepted) {
+        self->queue_cv_.notify_one();
+    }
 
     return DR_OK;
 }
@@ -1076,6 +1081,7 @@ void StreamConnection::_connection_thread_func() {
 }
 
 void StreamConnection::_decode_thread_func() {
+    std::optional<DecodeUnitQueue::DecodeUnit> queued_unit;
     AVPacket *pkt = nullptr;
 #ifdef __ANDROID__
     bool native_input_blocked = false;
@@ -1090,6 +1096,7 @@ void StreamConnection::_decode_thread_func() {
     }
 
     while (true) {
+        queued_unit.reset();
         pkt = nullptr;
         {
             std::unique_lock<std::mutex> lock(queue_mutex_);
@@ -1118,8 +1125,10 @@ void StreamConnection::_decode_thread_func() {
                 && !native_input_blocked
 #endif
             ) {
-                pkt = packet_queue_.front();
-                packet_queue_.erase(packet_queue_.begin());
+                queued_unit = packet_queue_.pop();
+                if (queued_unit) {
+                    pkt = queued_unit->packet.get();
+                }
             }
         }
 
@@ -1154,17 +1163,29 @@ void StreamConnection::_decode_thread_func() {
 
                 if (feed_result == AndroidMediaCodec::FeedResult::QUEUED) {
                     native_input_blocked = false;
-                    av_packet_free(&pkt);
+                    queued_unit.reset();
+                    pkt = nullptr;
                 } else if (feed_result == AndroidMediaCodec::FeedResult::BACKPRESSURE) {
                     native_input_blocked = !stale_codec;
-                    std::lock_guard<std::mutex> lock(queue_mutex_);
-                    packet_queue_.insert(packet_queue_.begin(), pkt);
+                    DecodeUnitQueue::PushResult requeue_result;
+                    {
+                        std::lock_guard<std::mutex> lock(queue_mutex_);
+                        requeue_result = packet_queue_.return_front(std::move(*queued_unit));
+                    }
+                    queued_unit.reset();
                     pkt = nullptr;
+                    if (requeue_result.dropped != 0) {
+                        frames_dropped_.fetch_add((int)requeue_result.dropped);
+                    }
+                    if (requeue_result.request_idr) {
+                        LiRequestIdrFrame();
+                    }
                 } else {
                     NF_LOGE("StreamConnection", "Native MediaCodec input failed; terminating stream");
                     decoder_ready_.store(false);
                     is_streaming_.store(false);
-                    av_packet_free(&pkt);
+                    queued_unit.reset();
+                    pkt = nullptr;
                     queue_cv_.notify_all();
                     LiInterruptConnection();
                 }
@@ -1347,14 +1368,16 @@ void StreamConnection::_decode_thread_func() {
                     }
                 }
             }
-            av_packet_free(&pkt);
+            queued_unit.reset();
+            pkt = nullptr;
             continue;
         }
 
         {
             AVCodecContext *ctx = decoder_->get_codec_context();
             if (!ctx) {
-                av_packet_free(&pkt);
+                queued_unit.reset();
+                pkt = nullptr;
                 continue;
             }
 
@@ -1406,7 +1429,8 @@ void StreamConnection::_decode_thread_func() {
 
             int send_ret = avcodec_send_packet(ctx, pkt);
 
-            av_packet_free(&pkt);
+            queued_unit.reset();
+            pkt = nullptr;
 
             if (send_ret < 0 && send_ret != AVERROR(EAGAIN) && send_ret != AVERROR_EOF) {
                 continue;
@@ -1542,9 +1566,6 @@ void StreamConnection::_decode_thread_func() {
 }
 
 void StreamConnection::_clear_packet_queue() {
-    for (auto *p : packet_queue_) {
-        av_packet_free(&p);
-    }
     packet_queue_.clear();
 }
 

--- a/addons/nightfall-stream/src/video/stream_connection.h
+++ b/addons/nightfall-stream/src/video/stream_connection.h
@@ -10,6 +10,7 @@
 #include <condition_variable>
 #include <vector>
 #include <chrono>
+#include <memory>
 
 extern "C" {
 #include <Limelight.h>
@@ -153,7 +154,13 @@ private:
         uint64_t owned_buffer_ptr = 0;
     };
 
-    std::atomic<AndroidMediaCodec *> native_codec_{nullptr};
+    std::shared_ptr<AndroidMediaCodec> _get_native_codec() const;
+    void _replace_native_codec(std::shared_ptr<AndroidMediaCodec> replacement);
+
+    mutable std::mutex native_codec_mutex_;
+    std::shared_ptr<AndroidMediaCodec> native_codec_;
+    std::atomic<bool> native_codec_event_{false};
+
     // Compute pipeline for YCbCr → RGBA conversion
     RID compute_shader_;
     RID compute_pipeline_;

--- a/addons/nightfall-stream/src/video/stream_connection.h
+++ b/addons/nightfall-stream/src/video/stream_connection.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "video/decode_unit_queue.h"
 #include "video/depth_bridge.h"
 #include <godot_cpp/classes/node.hpp>
 #include <godot_cpp/classes/shader_material.hpp>
@@ -125,7 +126,7 @@ private:
     std::atomic<int> last_frame_latency_us_{0};
     std::atomic<int64_t> last_submit_time_us_{0};
 
-    std::vector<AVPacket *> packet_queue_;
+    DecodeUnitQueue packet_queue_;
     mutable std::mutex queue_mutex_;
     std::condition_variable queue_cv_;
     std::thread decode_thread_;

--- a/addons/nightfall-stream/src/video/stream_connection.h
+++ b/addons/nightfall-stream/src/video/stream_connection.h
@@ -144,6 +144,15 @@ private:
     AVColorRange current_color_range_ = AVCOL_RANGE_UNSPECIFIED;
     bool local_capture_mode_ = false;
 #ifdef __ANDROID__
+    struct CachedAhbImport {
+        uint64_t buffer_id = 0;
+        uint64_t generation = 0;
+        RID texture;
+        RID sampler;
+        RID uniform_set;
+        uint64_t owned_buffer_ptr = 0;
+    };
+
     std::atomic<AndroidMediaCodec *> native_codec_{nullptr};
     // Compute pipeline for YCbCr → RGBA conversion
     RID compute_shader_;
@@ -156,20 +165,39 @@ private:
     int native_video_height_ = 0;
     int native_color_range_ = 0;
     int native_color_matrix_type_ = 0;
-    void _ensure_compute_pipeline(RenderingDevice *rd, int width, int height);
-    void _render_compute_dispatch(RID ycbcr_tex_rid, RID ycbcr_sampler_rid, uint64_t ahb_ptr, int width, int height);
-    void _render_compute_dispatch_rt(); // Called on render thread, reads pending_ members
-    void _render_free_pipeline_rt(); // Called on render thread, frees old pipeline resources
-    RID pending_ycbcr_tex_rid_;
-    RID pending_ycbcr_sampler_rid_;
+
+    void _ensure_compute_pipeline(RenderingDevice *rd, int width, int height,
+                                  uint64_t generation);
+    bool _get_or_create_ahb_import(RenderingDevice *rd, uint64_t buffer_ptr,
+                                   uint64_t buffer_id, int width, int height,
+                                   uint64_t generation);
+    bool _retire_removed_ahb_imports(const std::vector<uint64_t> &buffer_ids);
+    bool _retire_all_ahb_imports();
+    void _render_compute_dispatch_rt();
+    void _render_free_pipeline_rt();
+
     RID pending_free_pipeline_;
     RID pending_free_shader_;
     RID pending_free_sampler_;
     RID pending_free_tex_;
-    uint64_t pending_ahb_ptr_ = 0;
+
+    std::atomic<uint64_t> render_generation_{1};
+    std::mutex render_state_mutex_;
+    uint64_t pending_buffer_id_ = 0;
+    uint64_t pending_generation_ = 0;
+    RID pending_uncached_texture_;
+    RID pending_uncached_sampler_;
+    uint64_t pending_uncached_buffer_ptr_ = 0;
     int pending_width_ = 0, pending_height_ = 0;
-    int pending_color_range_ = 0, pending_color_matrix_type_ = 0;
+    bool pending_dispatch_cached_ = false;
+    bool pending_dispatch_ready_ = false;
     std::mutex pending_mutex_;
+
+    std::vector<CachedAhbImport> ahb_import_cache_;
+    std::vector<CachedAhbImport> pending_free_ahb_imports_;
+    uint64_t ahb_cache_hits_ = 0;
+    uint64_t ahb_cache_misses_ = 0;
+    std::mutex ahb_cache_mutex_;
 #endif
 };
 

--- a/test/decode_unit_queue_test.cpp
+++ b/test/decode_unit_queue_test.cpp
@@ -1,0 +1,98 @@
+#include "video/decode_unit_queue.h"
+
+#include <cassert>
+#include <utility>
+
+namespace {
+
+godot::DecodeUnitQueue::DecodeUnit make_unit(int frame_number, bool is_idr = false) {
+    godot::DecodeUnitQueue::DecodeUnit unit;
+    unit.packet.reset(av_packet_alloc());
+    assert(unit.packet);
+    unit.frame_number = frame_number;
+    unit.is_idr = is_idr;
+    unit.presentation_time_us = frame_number * 1000;
+    return unit;
+}
+
+void test_fifo_and_backpressure_return() {
+    godot::DecodeUnitQueue queue(2);
+    assert(queue.push(make_unit(1, true)).accepted);
+    assert(queue.push(make_unit(2)).accepted);
+
+    auto first = queue.pop();
+    assert(first && first->frame_number == 1);
+    assert(queue.return_front(std::move(*first)).accepted);
+
+    first = queue.pop();
+    auto second = queue.pop();
+    assert(first && first->frame_number == 1);
+    assert(second && second->frame_number == 2);
+    assert(queue.empty());
+}
+
+void test_overflow_waits_for_idr() {
+    godot::DecodeUnitQueue queue(2);
+    assert(queue.push(make_unit(1, true)).accepted);
+    assert(queue.push(make_unit(2)).accepted);
+
+    const auto overflow = queue.push(make_unit(3));
+    assert(!overflow.accepted);
+    assert(overflow.request_idr);
+    assert(overflow.dropped == 3);
+    assert(queue.empty());
+    assert(queue.awaiting_idr());
+
+    const auto dependent = queue.push(make_unit(4));
+    assert(!dependent.accepted);
+    assert(!dependent.request_idr);
+    assert(dependent.dropped == 1);
+
+    const auto recovery = queue.push(make_unit(5, true));
+    assert(recovery.accepted);
+    assert(!queue.awaiting_idr());
+    assert(queue.size() == 1);
+    auto idr = queue.pop();
+    assert(idr && idr->frame_number == 5);
+}
+
+void test_idr_replaces_full_backlog() {
+    godot::DecodeUnitQueue queue(2);
+    assert(queue.push(make_unit(1, true)).accepted);
+    assert(queue.push(make_unit(2)).accepted);
+
+    const auto recovery = queue.push(make_unit(3, true));
+    assert(recovery.accepted);
+    assert(!recovery.request_idr);
+    assert(recovery.dropped == 2);
+    assert(queue.size() == 1);
+
+    auto idr = queue.pop();
+    assert(idr && idr->frame_number == 3);
+}
+
+void test_requeue_is_bounded() {
+    godot::DecodeUnitQueue queue(2);
+    assert(queue.push(make_unit(1, true)).accepted);
+    assert(queue.push(make_unit(2)).accepted);
+    auto in_flight = queue.pop();
+    assert(in_flight && in_flight->frame_number == 1);
+
+    // A producer can fill the vacated slot while MediaCodec has no input slot.
+    assert(queue.push(make_unit(3)).accepted);
+    const auto requeue = queue.return_front(std::move(*in_flight));
+    assert(!requeue.accepted);
+    assert(requeue.request_idr);
+    assert(requeue.dropped == 3);
+    assert(queue.empty());
+    assert(queue.awaiting_idr());
+}
+
+} // namespace
+
+int main() {
+    test_fifo_and_backpressure_return();
+    test_overflow_waits_for_idr();
+    test_idr_replaces_full_backlog();
+    test_requeue_is_bounded();
+}


### PR DESCRIPTION
# Summary

> **Stacked-PR note:** This PR includes the changes from #7 and #8 **only because GitHub has poor support for stacked pull requests across forks**. Those commits are retained here to preserve the intended dependency order; review the commits separately, with the bounded-queue work in `410d823` as this PR's new item.

This PR completes the next latency-control step in the Android streaming pipeline:

1. **#7 — cache Android Hardware Buffer imports** (`e46b0a1`)
2. **#8 — make MediaCodec output event-driven** (`8509a66`)
3. **This PR — bound the compressed decode-unit queue** (`410d823`)

The queue previously used `std::vector<AVPacket *>`, removed from its front with `erase(begin())`, and could grow to 129–513 decode units. Under decoder overload this both increased per-packet work and allowed seconds of obsolete video to accumulate.

## Bounded low-latency queue

- Introduces `DecodeUnitQueue`, a small owning FIFO with a **four decode-unit** production limit.
- Replaces raw packet ownership with move-only RAII ownership, so queued, dropped, requeued, and cleared packets are released automatically.
- Uses `std::deque` operations for O(1) front removal and MediaCodec backpressure requeueing.
- Retains Limelight decode-unit metadata (`IDR` status, frame number, and presentation timestamp) while the unit is queued.

## Overload and recovery policy

Dropping an arbitrary compressed frame can invalidate later dependent frames. Rather than continuing to decode a stale or broken reference chain, the queue now:

1. Discards the obsolete queue when the bound is exceeded.
2. Requests an IDR after releasing the queue mutex.
3. Rejects dependent units while awaiting that IDR.
4. Resumes the sequence only once an IDR arrives.
5. Prefers a newly received IDR over a full stale backlog.

The policy no longer bases Android queue behavior on `decoder_->is_hw_decode()`, which describes the inactive FFmpeg decoder rather than the native MediaCodec flow.

MediaCodec input backpressure is handled without violating the bound: the decode thread returns the in-flight unit to the queue front when possible. If a producer filled the vacated slot first, the implementation drops the now-stale sequence and requests an IDR instead of growing the queue beyond its limit.

## Included prerequisite work

### #7: Android Hardware Buffer import caching

Caches import resources for the finite ImageReader buffer pool, avoiding repeated creation and destruction of the GPU import objects for stable Android Hardware Buffers.

### #8: Event-driven MediaCodec output

Uses asynchronous MediaCodec and ImageReader notifications to wake the decode thread, so input/output progress is no longer driven by polling delays.

## Validation

- Adds deterministic queue-policy tests covering:
  - FIFO order and backpressure requeueing;
  - overflow transition into IDR recovery;
  - suppression of dependent frames until an IDR arrives;
  - replacement of a full stale backlog by an IDR; and
  - the producer/requeue race that previously could exceed a naive bound.
- Registers the test with CTest for desktop builds.
- Ran the queue-policy test with a minimal FFmpeg API stub and verified `git diff --check`.

## Follow-up validation

The queue bound is intentionally conservative and should be measured on Quest under sustained 4K/72 FPS load, including forced MediaCodec input backpressure. Confirm that queue depth remains at or below four, IDR recovery resumes promptly, and end-to-end latency does not accumulate during render or decoder stalls.
