### PR TITLE
AI-3D: MiDaS depth-based stereo (Std/Fast/Fastest quality tiers)

### DIFF
--- a/addons/nightfall-stream/src/video/depth_bridge.cpp
+++ b/addons/nightfall-stream/src/video/depth_bridge.cpp
@@ -2,20 +2,38 @@
 #include "nf_log.h"
 
 #ifdef __ANDROID__
-#include <dlfcn.h>
 #include <jni.h>
+#include <android/log.h>
+
+// dlsym(RTLD_DEFAULT, "JNI_GetCreatedJavaVMs") (the old approach here) fails
+// on this device/NDK combo - modern Android's linker namespace isolation
+// keeps libnativehelper/libart symbols out of a GDExtension .so's default
+// symbol view, so every submit_depth_frame/get_depth_map/set_depth_model
+// call was silently getting a null JNIEnv and no-op'ing, for the whole
+// depth pipeline's lifetime. ffmpeg_decoder.cpp already solved this properly
+// for MediaCodec access: GodotApp.java's static initializer calls
+// initializeMoonlightJNI() before Godot even starts, which stashes a real
+// JavaVM* via env->GetJavaVM() - reuse that instead of re-deriving one.
+extern JavaVM *nightfall_get_jvm();
 
 static JNIEnv *get_jni_env() {
-    typedef jint (*JNI_GetCreatedJavaVMs_t)(JavaVM **, jsize, jsize *);
-    JNI_GetCreatedJavaVMs_t jni_get_created = (JNI_GetCreatedJavaVMs_t)dlsym(RTLD_DEFAULT, "JNI_GetCreatedJavaVMs");
-    if (!jni_get_created) return nullptr;
-    JavaVM *vm = nullptr;
-    jsize vm_count = 0;
-    jint result = jni_get_created(&vm, 1, &vm_count);
-    if (result != JNI_OK || vm_count == 0) return nullptr;
-    JNIEnv *env;
-    result = vm->AttachCurrentThread(&env, NULL);
-    if (result != JNI_OK) return nullptr;
+    JavaVM *vm = nightfall_get_jvm();
+    if (!vm) {
+        __android_log_print(ANDROID_LOG_ERROR, "DepthBridge", "get_jni_env: no JavaVM (initializeMoonlightJNI not called yet?)");
+        return nullptr;
+    }
+    JNIEnv *env = nullptr;
+    jint res = vm->GetEnv((void **)&env, JNI_VERSION_1_6);
+    if (res == JNI_EDETACHED) {
+        res = vm->AttachCurrentThread(&env, nullptr);
+        if (res != JNI_OK) {
+            __android_log_print(ANDROID_LOG_ERROR, "DepthBridge", "get_jni_env: AttachCurrentThread failed result=%d", res);
+            return nullptr;
+        }
+    } else if (res != JNI_OK) {
+        __android_log_print(ANDROID_LOG_ERROR, "DepthBridge", "get_jni_env: GetEnv failed result=%d", res);
+        return nullptr;
+    }
     return env;
 }
 #endif
@@ -86,13 +104,22 @@ PackedByteArray DepthBridge::get_depth_map() {
 void DepthBridge::set_depth_model(int model_index) {
 #ifdef __ANDROID__
     JNIEnv *env = get_jni_env();
-    if (!env) return;
+    if (!env) {
+        __android_log_print(ANDROID_LOG_ERROR, "DepthBridge", "set_depth_model: no JNIEnv");
+        return;
+    }
 
     jclass app_class = env->FindClass("com/godot/game/GodotApp");
-    if (!app_class) return;
+    if (!app_class) {
+        __android_log_print(ANDROID_LOG_ERROR, "DepthBridge", "set_depth_model: FindClass failed");
+        env->ExceptionClear();
+        return;
+    }
 
     jmethodID method = env->GetStaticMethodID(app_class, "setDepthModel", "(I)V");
     if (!method) {
+        __android_log_print(ANDROID_LOG_ERROR, "DepthBridge", "set_depth_model: GetStaticMethodID failed");
+        env->ExceptionClear();
         env->DeleteLocalRef(app_class);
         return;
     }

--- a/android/src/main/java/com/godot/game/DepthEstimator.java
+++ b/android/src/main/java/com/godot/game/DepthEstimator.java
@@ -22,7 +22,6 @@ public class DepthEstimator {
     private static final String TAG = "DepthEstimator";
     private static final int OUTPUT_SIZE = 256;
     private static final int DA_INPUT_SIZE = 256;
-    private static final int HQ_INPUT_SIZE = 256;
     private static final String MODEL_MIDAS = "midas-midas-v2-w8a8.tflite";
     // midas-midas-v2-w8a8.tflite's actual per-tensor quantization parameters,
     // read directly from the model via ai-edge-litert's Interpreter.get_input/
@@ -45,19 +44,11 @@ public class DepthEstimator {
 
     private Interpreter tfliteMidas;
     private Interpreter tfliteDepthAnything;
-    // Same underlying weights as tfliteMidas (MODEL_MIDAS), loaded as a genuinely
-    // separate Interpreter instance via NNAPI - lets model index 3 ("MiDaS-NNAPI")
-    // feed the occlusion-aware warp pipeline on its own Interpreter instance.
-    // Two instances from the same file share the OS page cache for the read-only
-    // weight bytes, so this isn't a second full copy of the model.
-    private Interpreter tfliteMidasHq;
     private Interpreter activeInterpreter;
     private ByteBuffer inputBufferMidas;
     private ByteBuffer inputBufferDA;
-    private ByteBuffer inputBufferHq;
     private ByteBuffer outputBufferMidas;
     private ByteBuffer outputBufferDA;
-    private ByteBuffer outputBufferHq;
     private volatile boolean initialized = false;
     private volatile int activeModelIndex = 0;
 
@@ -82,11 +73,9 @@ public class DepthEstimator {
             // bytes" (exactly 4x, the float32/uint8 ratio) on EVERY
             // inference call, deterministically - confirmed via full-session
             // log analysis (2026-08-18): 0 successes out of hundreds of
-            // calls across both runInferenceMidas (this model, model index
-            // 0) and runInferenceMidasHq (same model file, index 3),
-            // regardless of what other models had run before. Caught by
-            // submitFrame()'s try/catch, logged as "Async inference failed"
-            // but easy to miss next to the similarly-worded per-call
+            // calls, regardless of what other models had run before. Caught
+            // by submitFrame()'s try/catch, logged as "Async inference
+            // failed" but easy to miss next to the similarly-worded per-call
             // "Inference: Xms" duration log that still prints from the
             // finally block regardless of success. Only affects this w8a8
             // model - inputBufferDA (a genuinely different, float32 model)
@@ -104,15 +93,6 @@ public class DepthEstimator {
             outputBufferDA = ByteBuffer.allocateDirect(1 * DA_INPUT_SIZE * DA_INPUT_SIZE * 1 * 4)
                     .order(ByteOrder.nativeOrder());
 
-            // Same model file as inputBufferMidas (MODEL_MIDAS) - same UINT8
-            // input requirement, see the comment there.
-            inputBufferHq = ByteBuffer.allocateDirect(1 * HQ_INPUT_SIZE * HQ_INPUT_SIZE * 3)
-                    .order(ByteOrder.nativeOrder());
-            // Same model file as outputBufferMidas - same quantized UINT8
-            // output, see the comment there.
-            outputBufferHq = ByteBuffer.allocateDirect(1 * HQ_INPUT_SIZE * HQ_INPUT_SIZE * 1)
-                    .order(ByteOrder.nativeOrder());
-
             tfliteMidas = loadInterpreter(MODEL_MIDAS);
 
             try {
@@ -123,19 +103,8 @@ public class DepthEstimator {
                 tfliteDepthAnything = null;
             }
 
-            try {
-                // Same weights as MODEL_MIDAS (mode 0), separate instance, via the
-                // proven NNAPI-with-CPU-fallback path - feeds the occlusion-aware
-                // warp pipeline (stereo_mode 6) on its own Interpreter instance.
-                tfliteMidasHq = loadInterpreter(MODEL_MIDAS);
-                Log.i(TAG, "MiDaS-NNAPI (HQ) model loaded");
-            } catch (Exception e) {
-                Log.w(TAG, "MiDaS-NNAPI (HQ) model not available", e);
-                tfliteMidasHq = null;
-            }
-
             activeInterpreter = tfliteMidas;
-            activeModelIndex = 0;
+            activeModelIndex = 3;
             initialized = true;
             Log.i(TAG, "Initialized successfully (MiDaS=" + (tfliteMidas != null) + ", DA=" + (tfliteDepthAnything != null) + ")");
             return true;
@@ -167,11 +136,13 @@ public class DepthEstimator {
         Interpreter target;
         if (modelIndex == 1 && tfliteDepthAnything != null) {
             target = tfliteDepthAnything;
-        } else if (modelIndex == 3 && tfliteMidasHq != null) {
-            target = tfliteMidasHq;
         } else {
+            // MiDaS-Std and MiDaS-Fast (see settings_controller.gd) share this
+            // one interpreter - the separate "crude warp" MiDaS instance that
+            // used to live at index 0 is gone, so fold any other/unrecognized
+            // index into this one too rather than requiring index 3 exactly.
             target = tfliteMidas;
-            modelIndex = 0;
+            modelIndex = 3;
         }
         if (activeModelIndex != modelIndex) {
             while (isInferencing.get()) {
@@ -181,12 +152,7 @@ public class DepthEstimator {
             rangeValid = false;
             activeInterpreter = target;
             activeModelIndex = modelIndex;
-            String modelName;
-            switch (modelIndex) {
-                case 1: modelName = "Depth Anything V2"; break;
-                case 3: modelName = "MiDaS-NNAPI"; break;
-                default: modelName = "MiDaS"; break;
-            }
+            String modelName = (modelIndex == 1) ? "Depth Anything V2" : "MiDaS";
             Log.i(TAG, "Switched to model " + modelName);
         }
     }
@@ -208,8 +174,6 @@ public class DepthEstimator {
                 byte[] result;
                 if (modelIdx == 1) {
                     result = runInferenceDA(frameCopy, width, height);
-                } else if (modelIdx == 3) {
-                    result = runInferenceMidasHq(frameCopy, width, height);
                 } else {
                     result = runInferenceMidas(frameCopy, width, height);
                 }
@@ -221,12 +185,7 @@ public class DepthEstimator {
             } finally {
                 isInferencing.set(false);
                 long duration = (System.nanoTime() - startTime) / 1_000_000;
-                String modelName;
-                switch (modelIdx) {
-                    case 1: modelName = "DA"; break;
-                    case 3: modelName = "MiDaS-HQ"; break;
-                    default: modelName = "MiDaS"; break;
-                }
+                String modelName = (modelIdx == 1) ? "DA" : "MiDaS";
                 Log.d(TAG, "Inference: " + duration + "ms (" + modelName + ")");
             }
         });
@@ -237,40 +196,12 @@ public class DepthEstimator {
     }
 
     // real (0..1 normalized pixel) -> quantized uint8, per MIDAS_INPUT_SCALE/
-    // ZERO_POINT above. Shared by runInferenceMidas() and runInferenceMidasHq()
-    // - both use the same model file, so the same quantization applies.
+    // ZERO_POINT above.
     private static byte quantizeMidasInput(int rawPixelByte) {
         float real = (rawPixelByte & 0xFF) / 255.0f;
         int q = Math.round(real / MIDAS_INPUT_SCALE) + MIDAS_INPUT_ZERO_POINT;
         q = Math.max(0, Math.min(255, q));
         return (byte) q;
-    }
-
-    private byte[] runInferenceMidas(byte[] rgbaPixels, int width, int height) {
-        inputBufferMidas.rewind();
-        outputBufferMidas.rewind();
-
-        int srcRowBytes = width * 4;
-        float scaleX = (float) width / OUTPUT_SIZE;
-        float scaleY = (float) height / OUTPUT_SIZE;
-
-        for (int y = 0; y < OUTPUT_SIZE; y++) {
-            int srcY = Math.min((int) (y * scaleY), height - 1);
-            int srcRowOff = srcY * srcRowBytes;
-            for (int x = 0; x < OUTPUT_SIZE; x++) {
-                int srcX = Math.min((int) (x * scaleX), width - 1);
-                int srcIdx = srcRowOff + srcX * 4;
-                inputBufferMidas.put(quantizeMidasInput(rgbaPixels[srcIdx]));
-                inputBufferMidas.put(quantizeMidasInput(rgbaPixels[srcIdx + 1]));
-                inputBufferMidas.put(quantizeMidasInput(rgbaPixels[srcIdx + 2]));
-            }
-        }
-        inputBufferMidas.rewind();
-
-        tfliteMidas.run(inputBufferMidas, outputBufferMidas);
-        outputBufferMidas.rewind();
-
-        return postProcess(dequantizeMidasOutput(outputBufferMidas, OUTPUT_SIZE * OUTPUT_SIZE), OUTPUT_SIZE, true);
     }
 
     private byte[] runInferenceDA(byte[] rgbaPixels, int width, int height) {
@@ -300,41 +231,40 @@ public class DepthEstimator {
         return postProcess(extractFloatOutput(outputBufferDA, DA_INPUT_SIZE * DA_INPUT_SIZE), DA_INPUT_SIZE, true);
     }
 
-    // Same model weights as runInferenceMidas() (mode 0), but via the separate
-    // tfliteMidasHq NNAPI instance, feeding stereo_mode 6's warp pipeline. No
-    // dilate/blur here - the warp shader does its own edge-aware joint bilateral
-    // upsample against the actual color frame (depth_upsample.gdshader), which
-    // snaps depth to real edges instead of averaging small objects (taskbar
-    // icons, widgets) away like the CPU blur below does.
-    private byte[] runInferenceMidasHq(byte[] rgbaPixels, int width, int height) {
-        inputBufferHq.rewind();
-        outputBufferHq.rewind();
+    // No dilate/blur here - the warp shader does its own edge-aware joint
+    // bilateral upsample against the actual color frame
+    // (depth_upsample.gdshader), which snaps depth to real edges instead of
+    // averaging small objects (taskbar icons, widgets) away like a CPU blur
+    // would.
+    private byte[] runInferenceMidas(byte[] rgbaPixels, int width, int height) {
+        inputBufferMidas.rewind();
+        outputBufferMidas.rewind();
 
         int srcRowBytes = width * 4;
-        float scaleX = (float) width / HQ_INPUT_SIZE;
-        float scaleY = (float) height / HQ_INPUT_SIZE;
+        float scaleX = (float) width / OUTPUT_SIZE;
+        float scaleY = (float) height / OUTPUT_SIZE;
 
-        for (int y = 0; y < HQ_INPUT_SIZE; y++) {
+        for (int y = 0; y < OUTPUT_SIZE; y++) {
             int srcY = Math.min((int) (y * scaleY), height - 1);
             int srcRowOff = srcY * srcRowBytes;
-            for (int x = 0; x < HQ_INPUT_SIZE; x++) {
+            for (int x = 0; x < OUTPUT_SIZE; x++) {
                 int srcX = Math.min((int) (x * scaleX), width - 1);
                 int srcIdx = srcRowOff + srcX * 4;
-                inputBufferHq.put(quantizeMidasInput(rgbaPixels[srcIdx]));
-                inputBufferHq.put(quantizeMidasInput(rgbaPixels[srcIdx + 1]));
-                inputBufferHq.put(quantizeMidasInput(rgbaPixels[srcIdx + 2]));
+                inputBufferMidas.put(quantizeMidasInput(rgbaPixels[srcIdx]));
+                inputBufferMidas.put(quantizeMidasInput(rgbaPixels[srcIdx + 1]));
+                inputBufferMidas.put(quantizeMidasInput(rgbaPixels[srcIdx + 2]));
             }
         }
-        inputBufferHq.rewind();
+        inputBufferMidas.rewind();
 
-        tfliteMidasHq.run(inputBufferHq, outputBufferHq);
-        outputBufferHq.rewind();
+        tfliteMidas.run(inputBufferMidas, outputBufferMidas);
+        outputBufferMidas.rewind();
 
-        return postProcess(dequantizeMidasOutput(outputBufferHq, HQ_INPUT_SIZE * HQ_INPUT_SIZE), HQ_INPUT_SIZE, false);
+        return postProcess(dequantizeMidasOutput(outputBufferMidas, OUTPUT_SIZE * OUTPUT_SIZE), OUTPUT_SIZE, false);
     }
 
     // dequantize (quantized - zero_point) * scale, per MIDAS_OUTPUT_SCALE/
-    // ZERO_POINT above. Shared by runInferenceMidas() and runInferenceMidasHq().
+    // ZERO_POINT above.
     private static float[] dequantizeMidasOutput(ByteBuffer output, int count) {
         output.rewind();
         float[] raw = new float[count];
@@ -382,10 +312,10 @@ public class DepthEstimator {
     private boolean rangeValid = false;
 
     // Takes the already-decoded real-valued depth array, not a raw
-    // ByteBuffer - float32 output tensors (runInferenceDA) and quantized
-    // UINT8 ones (runInferenceMidas/runInferenceMidasHq) decode completely
-    // differently at the source (see each call site), and this logic
-    // downstream is identical either way once it's a plain float[].
+    // ByteBuffer - the float32 output tensor (runInferenceDA) and the
+    // quantized UINT8 one (runInferenceMidas) decode completely differently
+    // at the source (see each call site), and this logic downstream is
+    // identical either way once it's a plain float[].
     private byte[] postProcess(float[] raw, int size, boolean dilateAndBlur) {
         int count = size * size;
 
@@ -570,10 +500,6 @@ public class DepthEstimator {
         if (tfliteDepthAnything != null) {
             tfliteDepthAnything.close();
             tfliteDepthAnything = null;
-        }
-        if (tfliteMidasHq != null) {
-            tfliteMidasHq.close();
-            tfliteMidasHq = null;
         }
         activeInterpreter = null;
         initialized = false;

--- a/android/src/main/java/com/godot/game/DepthEstimator.java
+++ b/android/src/main/java/com/godot/game/DepthEstimator.java
@@ -5,9 +5,6 @@ import android.content.res.AssetFileDescriptor;
 import android.util.Log;
 
 import org.tensorflow.lite.Interpreter;
-import org.tensorflow.lite.gpu.CompatibilityList;
-import org.tensorflow.lite.gpu.GpuDelegate;
-import org.tensorflow.lite.gpu.GpuDelegateFactory;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -25,7 +22,6 @@ public class DepthEstimator {
     private static final String TAG = "DepthEstimator";
     private static final int OUTPUT_SIZE = 256;
     private static final int DA_INPUT_SIZE = 256;
-    private static final int GPU_INPUT_SIZE = 256;
     private static final int HQ_INPUT_SIZE = 256;
     private static final String MODEL_MIDAS = "midas-midas-v2-w8a8.tflite";
     // midas-midas-v2-w8a8.tflite's actual per-tensor quantization parameters,
@@ -46,34 +42,21 @@ public class DepthEstimator {
     private static final float MIDAS_OUTPUT_SCALE = 6.514299392700195f;
     private static final int MIDAS_OUTPUT_ZERO_POINT = 0;
     private static final String MODEL_DEPTH_ANYTHING = "depth-anything-v2-small.tflite";
-    // MiDaS v2.1 small, fp16, vendored from Gilleece/moonlight-android-xr's own
-    // conversion (tools/convert_midas.py there) of the MIT-licensed MIDAS_ISL
-    // ONNX export, for a same-model/same-delegate A/B comparison against our
-    // existing w8a8 CPU/NNAPI path. Comparison-only: this exact binary hasn't
-    // been re-derived from source here, so don't ship it without revisiting
-    // provenance/licensing.
-    private static final String MODEL_MIDAS_GPU = "midas_v21_small_256_fp16.tflite";
 
     private Interpreter tfliteMidas;
     private Interpreter tfliteDepthAnything;
-    private Interpreter tfliteMidasGpu;
-    private GpuDelegate gpuDelegateMidasGpu;
-    private boolean midasGpuAccelerated;
     // Same underlying weights as tfliteMidas (MODEL_MIDAS), loaded as a genuinely
     // separate Interpreter instance via NNAPI - lets model index 3 ("MiDaS-NNAPI")
-    // feed the new occlusion-aware warp pipeline without the GPU delegate's GLES
-    // context fighting Godot's own Vulkan renderer for the GPU (see runInferenceMidasHq()).
+    // feed the occlusion-aware warp pipeline on its own Interpreter instance.
     // Two instances from the same file share the OS page cache for the read-only
     // weight bytes, so this isn't a second full copy of the model.
     private Interpreter tfliteMidasHq;
     private Interpreter activeInterpreter;
     private ByteBuffer inputBufferMidas;
     private ByteBuffer inputBufferDA;
-    private ByteBuffer inputBufferGpu;
     private ByteBuffer inputBufferHq;
     private ByteBuffer outputBufferMidas;
     private ByteBuffer outputBufferDA;
-    private ByteBuffer outputBufferGpu;
     private ByteBuffer outputBufferHq;
     private volatile boolean initialized = false;
     private volatile int activeModelIndex = 0;
@@ -106,9 +89,8 @@ public class DepthEstimator {
             // but easy to miss next to the similarly-worded per-call
             // "Inference: Xms" duration log that still prints from the
             // finally block regardless of success. Only affects this w8a8
-            // model - inputBufferGpu (a real float32 fp16 model, confirmed
-            // 100% success rate in the same log analysis) and inputBufferDA
-            // are untouched.
+            // model - inputBufferDA (a genuinely different, float32 model)
+            // is untouched.
             inputBufferMidas = ByteBuffer.allocateDirect(1 * OUTPUT_SIZE * OUTPUT_SIZE * 3)
                     .order(ByteOrder.nativeOrder());
             // Output tensor ("depth_estimates") is ALSO quantized UINT8, not
@@ -120,11 +102,6 @@ public class DepthEstimator {
             inputBufferDA = ByteBuffer.allocateDirect(1 * DA_INPUT_SIZE * DA_INPUT_SIZE * 3 * 4)
                     .order(ByteOrder.nativeOrder());
             outputBufferDA = ByteBuffer.allocateDirect(1 * DA_INPUT_SIZE * DA_INPUT_SIZE * 1 * 4)
-                    .order(ByteOrder.nativeOrder());
-
-            inputBufferGpu = ByteBuffer.allocateDirect(1 * GPU_INPUT_SIZE * GPU_INPUT_SIZE * 3 * 4)
-                    .order(ByteOrder.nativeOrder());
-            outputBufferGpu = ByteBuffer.allocateDirect(1 * GPU_INPUT_SIZE * GPU_INPUT_SIZE * 1 * 4)
                     .order(ByteOrder.nativeOrder());
 
             // Same model file as inputBufferMidas (MODEL_MIDAS) - same UINT8
@@ -147,17 +124,9 @@ public class DepthEstimator {
             }
 
             try {
-                tfliteMidasGpu = loadMidasGpuInterpreter();
-                Log.i(TAG, "MiDaS v2.1-small GPU model loaded, accelerated=" + midasGpuAccelerated);
-            } catch (Exception e) {
-                Log.w(TAG, "MiDaS v2.1-small GPU model not available", e);
-                tfliteMidasGpu = null;
-            }
-
-            try {
                 // Same weights as MODEL_MIDAS (mode 0), separate instance, via the
-                // proven NNAPI-with-CPU-fallback path - feeds the new warp pipeline
-                // (stereo_mode 6) without the GPU delegate's GLES/Vulkan contention.
+                // proven NNAPI-with-CPU-fallback path - feeds the occlusion-aware
+                // warp pipeline (stereo_mode 6) on its own Interpreter instance.
                 tfliteMidasHq = loadInterpreter(MODEL_MIDAS);
                 Log.i(TAG, "MiDaS-NNAPI (HQ) model loaded");
             } catch (Exception e) {
@@ -193,56 +162,11 @@ public class DepthEstimator {
         }
     }
 
-    // Mirrors Gilleece/moonlight-android-xr's MidasDepthSource.initialize(): GPU
-    // delegate with fp16 precision loss allowed and sustained-speed preference,
-    // falling back to CPU only if delegate creation/model load fails. Unlike
-    // our other models this deliberately skips NNAPI - their comparison point
-    // is the GPU delegate specifically.
-    private Interpreter loadMidasGpuInterpreter() throws IOException {
-        MappedByteBuffer buffer = loadModelFile(MODEL_MIDAS_GPU);
-
-        CompatibilityList compatibility = new CompatibilityList();
-        Log.i(TAG, "MiDaS GPU: allowlist says " + compatibility.isDelegateSupportedOnThisDevice()
-                + ", trying the delegate anyway");
-
-        Interpreter.Options options = new Interpreter.Options();
-        try {
-            GpuDelegateFactory.Options gpuOptions = new GpuDelegateFactory.Options();
-            gpuOptions.setPrecisionLossAllowed(true);
-            gpuOptions.setInferencePreference(
-                    GpuDelegateFactory.Options.INFERENCE_PREFERENCE_SUSTAINED_SPEED);
-            gpuDelegateMidasGpu = new GpuDelegate(gpuOptions);
-            options.addDelegate(gpuDelegateMidasGpu);
-            midasGpuAccelerated = true;
-        } catch (Exception e) {
-            Log.w(TAG, "MiDaS GPU delegate creation failed, using CPU: " + e.getMessage());
-        }
-        if (!midasGpuAccelerated) {
-            options.setNumThreads(2);
-        }
-
-        try {
-            return new Interpreter(buffer, options);
-        } catch (Exception e) {
-            Log.w(TAG, "MiDaS GPU model failed to load with the GPU delegate: " + e.getMessage());
-            if (gpuDelegateMidasGpu != null) {
-                gpuDelegateMidasGpu.close();
-                gpuDelegateMidasGpu = null;
-            }
-            midasGpuAccelerated = false;
-            Interpreter.Options cpuOptions = new Interpreter.Options();
-            cpuOptions.setNumThreads(2);
-            return new Interpreter(buffer, cpuOptions);
-        }
-    }
-
     public void setActiveModel(int modelIndex) {
         if (!initialized) return;
         Interpreter target;
         if (modelIndex == 1 && tfliteDepthAnything != null) {
             target = tfliteDepthAnything;
-        } else if (modelIndex == 2 && tfliteMidasGpu != null) {
-            target = tfliteMidasGpu;
         } else if (modelIndex == 3 && tfliteMidasHq != null) {
             target = tfliteMidasHq;
         } else {
@@ -260,7 +184,6 @@ public class DepthEstimator {
             String modelName;
             switch (modelIndex) {
                 case 1: modelName = "Depth Anything V2"; break;
-                case 2: modelName = "MiDaS-GPU"; break;
                 case 3: modelName = "MiDaS-NNAPI"; break;
                 default: modelName = "MiDaS"; break;
             }
@@ -285,8 +208,6 @@ public class DepthEstimator {
                 byte[] result;
                 if (modelIdx == 1) {
                     result = runInferenceDA(frameCopy, width, height);
-                } else if (modelIdx == 2) {
-                    result = runInferenceMidasGpu(frameCopy, width, height);
                 } else if (modelIdx == 3) {
                     result = runInferenceMidasHq(frameCopy, width, height);
                 } else {
@@ -303,7 +224,6 @@ public class DepthEstimator {
                 String modelName;
                 switch (modelIdx) {
                     case 1: modelName = "DA"; break;
-                    case 2: modelName = "MiDaS-GPU"; break;
                     case 3: modelName = "MiDaS-HQ"; break;
                     default: modelName = "MiDaS"; break;
                 }
@@ -380,41 +300,12 @@ public class DepthEstimator {
         return postProcess(extractFloatOutput(outputBufferDA, DA_INPUT_SIZE * DA_INPUT_SIZE), DA_INPUT_SIZE, true);
     }
 
-    private byte[] runInferenceMidasGpu(byte[] rgbaPixels, int width, int height) {
-        inputBufferGpu.rewind();
-        outputBufferGpu.rewind();
-
-        int srcRowBytes = width * 4;
-        float scaleX = (float) width / GPU_INPUT_SIZE;
-        float scaleY = (float) height / GPU_INPUT_SIZE;
-
-        for (int y = 0; y < GPU_INPUT_SIZE; y++) {
-            int srcY = Math.min((int) (y * scaleY), height - 1);
-            int srcRowOff = srcY * srcRowBytes;
-            for (int x = 0; x < GPU_INPUT_SIZE; x++) {
-                int srcX = Math.min((int) (x * scaleX), width - 1);
-                int srcIdx = srcRowOff + srcX * 4;
-                inputBufferGpu.putFloat((rgbaPixels[srcIdx] & 0xFF) / 255.0f);
-                inputBufferGpu.putFloat((rgbaPixels[srcIdx + 1] & 0xFF) / 255.0f);
-                inputBufferGpu.putFloat((rgbaPixels[srcIdx + 2] & 0xFF) / 255.0f);
-            }
-        }
-        inputBufferGpu.rewind();
-
-        tfliteMidasGpu.run(inputBufferGpu, outputBufferGpu);
-        outputBufferGpu.rewind();
-
-        // No dilate/blur here - the warp shader does its own edge-aware joint
-        // bilateral upsample against the actual color frame (stereo_screen.gdshader,
-        // stereo_mode 5), which snaps depth to real edges instead of averaging
-        // small objects (taskbar icons, widgets) away like the CPU blur below does.
-        return postProcess(extractFloatOutput(outputBufferGpu, GPU_INPUT_SIZE * GPU_INPUT_SIZE), GPU_INPUT_SIZE, false);
-    }
-
     // Same model weights as runInferenceMidas() (mode 0), but via the separate
     // tfliteMidasHq NNAPI instance, feeding stereo_mode 6's warp pipeline. No
-    // dilate/blur here either, for the same reason as runInferenceMidasGpu() above -
-    // this is model-independent, not specific to which delegate produced the depth.
+    // dilate/blur here - the warp shader does its own edge-aware joint bilateral
+    // upsample against the actual color frame (depth_upsample.gdshader), which
+    // snaps depth to real edges instead of averaging small objects (taskbar
+    // icons, widgets) away like the CPU blur below does.
     private byte[] runInferenceMidasHq(byte[] rgbaPixels, int width, int height) {
         inputBufferHq.rewind();
         outputBufferHq.rewind();
@@ -455,8 +346,7 @@ public class DepthEstimator {
     }
 
     // Plain float32 output tensor extraction, for models that genuinely are
-    // float32 (runInferenceDA/runInferenceMidasGpu) - not quantized like the
-    // w8a8 MiDaS model.
+    // float32 (runInferenceDA) - not quantized like the w8a8 MiDaS model.
     private static float[] extractFloatOutput(ByteBuffer output, int count) {
         output.rewind();
         FloatBuffer floatOut = output.asFloatBuffer();
@@ -492,10 +382,10 @@ public class DepthEstimator {
     private boolean rangeValid = false;
 
     // Takes the already-decoded real-valued depth array, not a raw
-    // ByteBuffer - float32 output tensors (runInferenceDA/runInferenceMidasGpu)
-    // and quantized UINT8 ones (runInferenceMidas/runInferenceMidasHq) decode
-    // completely differently at the source (see each call site), and this
-    // logic downstream is identical either way once it's a plain float[].
+    // ByteBuffer - float32 output tensors (runInferenceDA) and quantized
+    // UINT8 ones (runInferenceMidas/runInferenceMidasHq) decode completely
+    // differently at the source (see each call site), and this logic
+    // downstream is identical either way once it's a plain float[].
     private byte[] postProcess(float[] raw, int size, boolean dilateAndBlur) {
         int count = size * size;
 
@@ -680,14 +570,6 @@ public class DepthEstimator {
         if (tfliteDepthAnything != null) {
             tfliteDepthAnything.close();
             tfliteDepthAnything = null;
-        }
-        if (tfliteMidasGpu != null) {
-            tfliteMidasGpu.close();
-            tfliteMidasGpu = null;
-        }
-        if (gpuDelegateMidasGpu != null) {
-            gpuDelegateMidasGpu.close();
-            gpuDelegateMidasGpu = null;
         }
         if (tfliteMidasHq != null) {
             tfliteMidasHq.close();

--- a/android/src/main/java/com/godot/game/DepthEstimator.java
+++ b/android/src/main/java/com/godot/game/DepthEstimator.java
@@ -28,6 +28,23 @@ public class DepthEstimator {
     private static final int GPU_INPUT_SIZE = 256;
     private static final int HQ_INPUT_SIZE = 256;
     private static final String MODEL_MIDAS = "midas-midas-v2-w8a8.tflite";
+    // midas-midas-v2-w8a8.tflite's actual per-tensor quantization parameters,
+    // read directly from the model via ai-edge-litert's Interpreter.get_input/
+    // output_details() (2026-08-18) - NOT assumed. Both the input ("image")
+    // and output ("depth_estimates") tensors are UINT8, not float32:
+    //   input:  scale=0.00487531116232276, zero_point=24
+    //   output: scale=6.514299392700195,   zero_point=0
+    // Getting either of these wrong doesn't throw - the interpreter runs
+    // "successfully" and produces silently garbage output (confirmed:
+    // sending raw 0..255 pixel bytes as input, and reading the output
+    // ByteBuffer via asFloatBuffer() as if it were float32, both "worked"
+    // with zero exceptions but produced near-black noise). The real/dequantized
+    // value is (quantized - zero_point) * scale; quantizing the other
+    // direction is round(real / scale) + zero_point, clamped to 0..255.
+    private static final float MIDAS_INPUT_SCALE = 0.00487531116232276f;
+    private static final int MIDAS_INPUT_ZERO_POINT = 24;
+    private static final float MIDAS_OUTPUT_SCALE = 6.514299392700195f;
+    private static final int MIDAS_OUTPUT_ZERO_POINT = 0;
     private static final String MODEL_DEPTH_ANYTHING = "depth-anything-v2-small.tflite";
     // MiDaS v2.1 small, fp16, vendored from Gilleece/moonlight-android-xr's own
     // conversion (tools/convert_midas.py there) of the MIT-licensed MIDAS_ISL
@@ -74,9 +91,30 @@ public class DepthEstimator {
         appContext = context.getApplicationContext();
 
         try {
-            inputBufferMidas = ByteBuffer.allocateDirect(1 * OUTPUT_SIZE * OUTPUT_SIZE * 3 * 4)
+            // midas-midas-v2-w8a8.tflite ("w8a8" = 8-bit weights AND
+            // activations) takes a quantized UINT8 input tensor (raw
+            // 0..255 pixel bytes, no normalization) - NOT float32. Sending
+            // float32 here throws "Cannot copy to a TensorFlowLite tensor
+            // (image) with 196608 bytes from a Java Buffer with 786432
+            // bytes" (exactly 4x, the float32/uint8 ratio) on EVERY
+            // inference call, deterministically - confirmed via full-session
+            // log analysis (2026-08-18): 0 successes out of hundreds of
+            // calls across both runInferenceMidas (this model, model index
+            // 0) and runInferenceMidasHq (same model file, index 3),
+            // regardless of what other models had run before. Caught by
+            // submitFrame()'s try/catch, logged as "Async inference failed"
+            // but easy to miss next to the similarly-worded per-call
+            // "Inference: Xms" duration log that still prints from the
+            // finally block regardless of success. Only affects this w8a8
+            // model - inputBufferGpu (a real float32 fp16 model, confirmed
+            // 100% success rate in the same log analysis) and inputBufferDA
+            // are untouched.
+            inputBufferMidas = ByteBuffer.allocateDirect(1 * OUTPUT_SIZE * OUTPUT_SIZE * 3)
                     .order(ByteOrder.nativeOrder());
-            outputBufferMidas = ByteBuffer.allocateDirect(1 * OUTPUT_SIZE * OUTPUT_SIZE * 1 * 4)
+            // Output tensor ("depth_estimates") is ALSO quantized UINT8, not
+            // float32 - see MIDAS_OUTPUT_SCALE/ZERO_POINT above. 1 byte/pixel,
+            // not 4.
+            outputBufferMidas = ByteBuffer.allocateDirect(1 * OUTPUT_SIZE * OUTPUT_SIZE * 1)
                     .order(ByteOrder.nativeOrder());
 
             inputBufferDA = ByteBuffer.allocateDirect(1 * DA_INPUT_SIZE * DA_INPUT_SIZE * 3 * 4)
@@ -89,9 +127,13 @@ public class DepthEstimator {
             outputBufferGpu = ByteBuffer.allocateDirect(1 * GPU_INPUT_SIZE * GPU_INPUT_SIZE * 1 * 4)
                     .order(ByteOrder.nativeOrder());
 
-            inputBufferHq = ByteBuffer.allocateDirect(1 * HQ_INPUT_SIZE * HQ_INPUT_SIZE * 3 * 4)
+            // Same model file as inputBufferMidas (MODEL_MIDAS) - same UINT8
+            // input requirement, see the comment there.
+            inputBufferHq = ByteBuffer.allocateDirect(1 * HQ_INPUT_SIZE * HQ_INPUT_SIZE * 3)
                     .order(ByteOrder.nativeOrder());
-            outputBufferHq = ByteBuffer.allocateDirect(1 * HQ_INPUT_SIZE * HQ_INPUT_SIZE * 1 * 4)
+            // Same model file as outputBufferMidas - same quantized UINT8
+            // output, see the comment there.
+            outputBufferHq = ByteBuffer.allocateDirect(1 * HQ_INPUT_SIZE * HQ_INPUT_SIZE * 1)
                     .order(ByteOrder.nativeOrder());
 
             tfliteMidas = loadInterpreter(MODEL_MIDAS);
@@ -274,6 +316,16 @@ public class DepthEstimator {
         return latestDepthMap.getAndSet(null);
     }
 
+    // real (0..1 normalized pixel) -> quantized uint8, per MIDAS_INPUT_SCALE/
+    // ZERO_POINT above. Shared by runInferenceMidas() and runInferenceMidasHq()
+    // - both use the same model file, so the same quantization applies.
+    private static byte quantizeMidasInput(int rawPixelByte) {
+        float real = (rawPixelByte & 0xFF) / 255.0f;
+        int q = Math.round(real / MIDAS_INPUT_SCALE) + MIDAS_INPUT_ZERO_POINT;
+        q = Math.max(0, Math.min(255, q));
+        return (byte) q;
+    }
+
     private byte[] runInferenceMidas(byte[] rgbaPixels, int width, int height) {
         inputBufferMidas.rewind();
         outputBufferMidas.rewind();
@@ -288,9 +340,9 @@ public class DepthEstimator {
             for (int x = 0; x < OUTPUT_SIZE; x++) {
                 int srcX = Math.min((int) (x * scaleX), width - 1);
                 int srcIdx = srcRowOff + srcX * 4;
-                inputBufferMidas.putFloat((rgbaPixels[srcIdx] & 0xFF) / 255.0f);
-                inputBufferMidas.putFloat((rgbaPixels[srcIdx + 1] & 0xFF) / 255.0f);
-                inputBufferMidas.putFloat((rgbaPixels[srcIdx + 2] & 0xFF) / 255.0f);
+                inputBufferMidas.put(quantizeMidasInput(rgbaPixels[srcIdx]));
+                inputBufferMidas.put(quantizeMidasInput(rgbaPixels[srcIdx + 1]));
+                inputBufferMidas.put(quantizeMidasInput(rgbaPixels[srcIdx + 2]));
             }
         }
         inputBufferMidas.rewind();
@@ -298,7 +350,7 @@ public class DepthEstimator {
         tfliteMidas.run(inputBufferMidas, outputBufferMidas);
         outputBufferMidas.rewind();
 
-        return postProcess(outputBufferMidas, OUTPUT_SIZE, true);
+        return postProcess(dequantizeMidasOutput(outputBufferMidas, OUTPUT_SIZE * OUTPUT_SIZE), OUTPUT_SIZE, true);
     }
 
     private byte[] runInferenceDA(byte[] rgbaPixels, int width, int height) {
@@ -325,7 +377,7 @@ public class DepthEstimator {
         tfliteDepthAnything.run(inputBufferDA, outputBufferDA);
         outputBufferDA.rewind();
 
-        return postProcess(outputBufferDA, DA_INPUT_SIZE, true);
+        return postProcess(extractFloatOutput(outputBufferDA, DA_INPUT_SIZE * DA_INPUT_SIZE), DA_INPUT_SIZE, true);
     }
 
     private byte[] runInferenceMidasGpu(byte[] rgbaPixels, int width, int height) {
@@ -356,7 +408,7 @@ public class DepthEstimator {
         // bilateral upsample against the actual color frame (stereo_screen.gdshader,
         // stereo_mode 5), which snaps depth to real edges instead of averaging
         // small objects (taskbar icons, widgets) away like the CPU blur below does.
-        return postProcess(outputBufferGpu, GPU_INPUT_SIZE, false);
+        return postProcess(extractFloatOutput(outputBufferGpu, GPU_INPUT_SIZE * GPU_INPUT_SIZE), GPU_INPUT_SIZE, false);
     }
 
     // Same model weights as runInferenceMidas() (mode 0), but via the separate
@@ -377,9 +429,9 @@ public class DepthEstimator {
             for (int x = 0; x < HQ_INPUT_SIZE; x++) {
                 int srcX = Math.min((int) (x * scaleX), width - 1);
                 int srcIdx = srcRowOff + srcX * 4;
-                inputBufferHq.putFloat((rgbaPixels[srcIdx] & 0xFF) / 255.0f);
-                inputBufferHq.putFloat((rgbaPixels[srcIdx + 1] & 0xFF) / 255.0f);
-                inputBufferHq.putFloat((rgbaPixels[srcIdx + 2] & 0xFF) / 255.0f);
+                inputBufferHq.put(quantizeMidasInput(rgbaPixels[srcIdx]));
+                inputBufferHq.put(quantizeMidasInput(rgbaPixels[srcIdx + 1]));
+                inputBufferHq.put(quantizeMidasInput(rgbaPixels[srcIdx + 2]));
             }
         }
         inputBufferHq.rewind();
@@ -387,7 +439,32 @@ public class DepthEstimator {
         tfliteMidasHq.run(inputBufferHq, outputBufferHq);
         outputBufferHq.rewind();
 
-        return postProcess(outputBufferHq, HQ_INPUT_SIZE, false);
+        return postProcess(dequantizeMidasOutput(outputBufferHq, HQ_INPUT_SIZE * HQ_INPUT_SIZE), HQ_INPUT_SIZE, false);
+    }
+
+    // dequantize (quantized - zero_point) * scale, per MIDAS_OUTPUT_SCALE/
+    // ZERO_POINT above. Shared by runInferenceMidas() and runInferenceMidasHq().
+    private static float[] dequantizeMidasOutput(ByteBuffer output, int count) {
+        output.rewind();
+        float[] raw = new float[count];
+        for (int i = 0; i < count; i++) {
+            int q = output.get(i) & 0xFF;
+            raw[i] = (q - MIDAS_OUTPUT_ZERO_POINT) * MIDAS_OUTPUT_SCALE;
+        }
+        return raw;
+    }
+
+    // Plain float32 output tensor extraction, for models that genuinely are
+    // float32 (runInferenceDA/runInferenceMidasGpu) - not quantized like the
+    // w8a8 MiDaS model.
+    private static float[] extractFloatOutput(ByteBuffer output, int count) {
+        output.rewind();
+        FloatBuffer floatOut = output.asFloatBuffer();
+        float[] raw = new float[count];
+        for (int i = 0; i < count; i++) {
+            raw[i] = floatOut.get(i);
+        }
+        return raw;
     }
 
     // Ported from Gilleece/moonlight-android-xr's xr_renderer.c
@@ -414,14 +491,13 @@ public class DepthEstimator {
     private float smoothHi = 1.0f;
     private boolean rangeValid = false;
 
-    private byte[] postProcess(ByteBuffer output, int size, boolean dilateAndBlur) {
-        output.rewind();
-        FloatBuffer floatOut = output.asFloatBuffer();
+    // Takes the already-decoded real-valued depth array, not a raw
+    // ByteBuffer - float32 output tensors (runInferenceDA/runInferenceMidasGpu)
+    // and quantized UINT8 ones (runInferenceMidas/runInferenceMidasHq) decode
+    // completely differently at the source (see each call site), and this
+    // logic downstream is identical either way once it's a plain float[].
+    private byte[] postProcess(float[] raw, int size, boolean dilateAndBlur) {
         int count = size * size;
-        float[] raw = new float[count];
-        for (int i = 0; i < count; i++) {
-            raw[i] = floatOut.get(i);
-        }
 
         float[] loHi = robustRange(raw, count);
         if (!rangeValid) {

--- a/android/src/main/java/com/godot/game/DepthEstimator.java
+++ b/android/src/main/java/com/godot/game/DepthEstimator.java
@@ -5,6 +5,9 @@ import android.content.res.AssetFileDescriptor;
 import android.util.Log;
 
 import org.tensorflow.lite.Interpreter;
+import org.tensorflow.lite.gpu.CompatibilityList;
+import org.tensorflow.lite.gpu.GpuDelegate;
+import org.tensorflow.lite.gpu.GpuDelegateFactory;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -22,16 +25,39 @@ public class DepthEstimator {
     private static final String TAG = "DepthEstimator";
     private static final int OUTPUT_SIZE = 256;
     private static final int DA_INPUT_SIZE = 256;
+    private static final int GPU_INPUT_SIZE = 256;
+    private static final int HQ_INPUT_SIZE = 256;
     private static final String MODEL_MIDAS = "midas-midas-v2-w8a8.tflite";
     private static final String MODEL_DEPTH_ANYTHING = "depth-anything-v2-small.tflite";
+    // MiDaS v2.1 small, fp16, vendored from Gilleece/moonlight-android-xr's own
+    // conversion (tools/convert_midas.py there) of the MIT-licensed MIDAS_ISL
+    // ONNX export, for a same-model/same-delegate A/B comparison against our
+    // existing w8a8 CPU/NNAPI path. Comparison-only: this exact binary hasn't
+    // been re-derived from source here, so don't ship it without revisiting
+    // provenance/licensing.
+    private static final String MODEL_MIDAS_GPU = "midas_v21_small_256_fp16.tflite";
 
     private Interpreter tfliteMidas;
     private Interpreter tfliteDepthAnything;
+    private Interpreter tfliteMidasGpu;
+    private GpuDelegate gpuDelegateMidasGpu;
+    private boolean midasGpuAccelerated;
+    // Same underlying weights as tfliteMidas (MODEL_MIDAS), loaded as a genuinely
+    // separate Interpreter instance via NNAPI - lets model index 3 ("MiDaS-NNAPI")
+    // feed the new occlusion-aware warp pipeline without the GPU delegate's GLES
+    // context fighting Godot's own Vulkan renderer for the GPU (see runInferenceMidasHq()).
+    // Two instances from the same file share the OS page cache for the read-only
+    // weight bytes, so this isn't a second full copy of the model.
+    private Interpreter tfliteMidasHq;
     private Interpreter activeInterpreter;
     private ByteBuffer inputBufferMidas;
     private ByteBuffer inputBufferDA;
+    private ByteBuffer inputBufferGpu;
+    private ByteBuffer inputBufferHq;
     private ByteBuffer outputBufferMidas;
     private ByteBuffer outputBufferDA;
+    private ByteBuffer outputBufferGpu;
+    private ByteBuffer outputBufferHq;
     private volatile boolean initialized = false;
     private volatile int activeModelIndex = 0;
 
@@ -39,7 +65,6 @@ public class DepthEstimator {
     private final AtomicBoolean isInferencing = new AtomicBoolean(false);
     private final AtomicReference<byte[]> latestDepthMap = new AtomicReference<>();
 
-    private byte[] previousDepthBytes = null;
     private float[] smoothedDepthFloat = null;
 
     private Context appContext;
@@ -59,6 +84,16 @@ public class DepthEstimator {
             outputBufferDA = ByteBuffer.allocateDirect(1 * DA_INPUT_SIZE * DA_INPUT_SIZE * 1 * 4)
                     .order(ByteOrder.nativeOrder());
 
+            inputBufferGpu = ByteBuffer.allocateDirect(1 * GPU_INPUT_SIZE * GPU_INPUT_SIZE * 3 * 4)
+                    .order(ByteOrder.nativeOrder());
+            outputBufferGpu = ByteBuffer.allocateDirect(1 * GPU_INPUT_SIZE * GPU_INPUT_SIZE * 1 * 4)
+                    .order(ByteOrder.nativeOrder());
+
+            inputBufferHq = ByteBuffer.allocateDirect(1 * HQ_INPUT_SIZE * HQ_INPUT_SIZE * 3 * 4)
+                    .order(ByteOrder.nativeOrder());
+            outputBufferHq = ByteBuffer.allocateDirect(1 * HQ_INPUT_SIZE * HQ_INPUT_SIZE * 1 * 4)
+                    .order(ByteOrder.nativeOrder());
+
             tfliteMidas = loadInterpreter(MODEL_MIDAS);
 
             try {
@@ -67,6 +102,25 @@ public class DepthEstimator {
             } catch (Exception e) {
                 Log.w(TAG, "Depth Anything V2 model not available", e);
                 tfliteDepthAnything = null;
+            }
+
+            try {
+                tfliteMidasGpu = loadMidasGpuInterpreter();
+                Log.i(TAG, "MiDaS v2.1-small GPU model loaded, accelerated=" + midasGpuAccelerated);
+            } catch (Exception e) {
+                Log.w(TAG, "MiDaS v2.1-small GPU model not available", e);
+                tfliteMidasGpu = null;
+            }
+
+            try {
+                // Same weights as MODEL_MIDAS (mode 0), separate instance, via the
+                // proven NNAPI-with-CPU-fallback path - feeds the new warp pipeline
+                // (stereo_mode 6) without the GPU delegate's GLES/Vulkan contention.
+                tfliteMidasHq = loadInterpreter(MODEL_MIDAS);
+                Log.i(TAG, "MiDaS-NNAPI (HQ) model loaded");
+            } catch (Exception e) {
+                Log.w(TAG, "MiDaS-NNAPI (HQ) model not available", e);
+                tfliteMidasHq = null;
             }
 
             activeInterpreter = tfliteMidas;
@@ -97,11 +151,58 @@ public class DepthEstimator {
         }
     }
 
+    // Mirrors Gilleece/moonlight-android-xr's MidasDepthSource.initialize(): GPU
+    // delegate with fp16 precision loss allowed and sustained-speed preference,
+    // falling back to CPU only if delegate creation/model load fails. Unlike
+    // our other models this deliberately skips NNAPI - their comparison point
+    // is the GPU delegate specifically.
+    private Interpreter loadMidasGpuInterpreter() throws IOException {
+        MappedByteBuffer buffer = loadModelFile(MODEL_MIDAS_GPU);
+
+        CompatibilityList compatibility = new CompatibilityList();
+        Log.i(TAG, "MiDaS GPU: allowlist says " + compatibility.isDelegateSupportedOnThisDevice()
+                + ", trying the delegate anyway");
+
+        Interpreter.Options options = new Interpreter.Options();
+        try {
+            GpuDelegateFactory.Options gpuOptions = new GpuDelegateFactory.Options();
+            gpuOptions.setPrecisionLossAllowed(true);
+            gpuOptions.setInferencePreference(
+                    GpuDelegateFactory.Options.INFERENCE_PREFERENCE_SUSTAINED_SPEED);
+            gpuDelegateMidasGpu = new GpuDelegate(gpuOptions);
+            options.addDelegate(gpuDelegateMidasGpu);
+            midasGpuAccelerated = true;
+        } catch (Exception e) {
+            Log.w(TAG, "MiDaS GPU delegate creation failed, using CPU: " + e.getMessage());
+        }
+        if (!midasGpuAccelerated) {
+            options.setNumThreads(2);
+        }
+
+        try {
+            return new Interpreter(buffer, options);
+        } catch (Exception e) {
+            Log.w(TAG, "MiDaS GPU model failed to load with the GPU delegate: " + e.getMessage());
+            if (gpuDelegateMidasGpu != null) {
+                gpuDelegateMidasGpu.close();
+                gpuDelegateMidasGpu = null;
+            }
+            midasGpuAccelerated = false;
+            Interpreter.Options cpuOptions = new Interpreter.Options();
+            cpuOptions.setNumThreads(2);
+            return new Interpreter(buffer, cpuOptions);
+        }
+    }
+
     public void setActiveModel(int modelIndex) {
         if (!initialized) return;
         Interpreter target;
         if (modelIndex == 1 && tfliteDepthAnything != null) {
             target = tfliteDepthAnything;
+        } else if (modelIndex == 2 && tfliteMidasGpu != null) {
+            target = tfliteMidasGpu;
+        } else if (modelIndex == 3 && tfliteMidasHq != null) {
+            target = tfliteMidasHq;
         } else {
             target = tfliteMidas;
             modelIndex = 0;
@@ -110,11 +211,18 @@ public class DepthEstimator {
             while (isInferencing.get()) {
                 Thread.yield();
             }
-            previousDepthBytes = null;
             smoothedDepthFloat = null;
+            rangeValid = false;
             activeInterpreter = target;
             activeModelIndex = modelIndex;
-            Log.i(TAG, "Switched to model " + (modelIndex == 0 ? "MiDaS" : "Depth Anything V2"));
+            String modelName;
+            switch (modelIndex) {
+                case 1: modelName = "Depth Anything V2"; break;
+                case 2: modelName = "MiDaS-GPU"; break;
+                case 3: modelName = "MiDaS-NNAPI"; break;
+                default: modelName = "MiDaS"; break;
+            }
+            Log.i(TAG, "Switched to model " + modelName);
         }
     }
 
@@ -135,6 +243,10 @@ public class DepthEstimator {
                 byte[] result;
                 if (modelIdx == 1) {
                     result = runInferenceDA(frameCopy, width, height);
+                } else if (modelIdx == 2) {
+                    result = runInferenceMidasGpu(frameCopy, width, height);
+                } else if (modelIdx == 3) {
+                    result = runInferenceMidasHq(frameCopy, width, height);
                 } else {
                     result = runInferenceMidas(frameCopy, width, height);
                 }
@@ -146,7 +258,14 @@ public class DepthEstimator {
             } finally {
                 isInferencing.set(false);
                 long duration = (System.nanoTime() - startTime) / 1_000_000;
-                Log.d(TAG, "Inference: " + duration + "ms (" + (modelIdx == 1 ? "DA" : "MiDaS") + ")");
+                String modelName;
+                switch (modelIdx) {
+                    case 1: modelName = "DA"; break;
+                    case 2: modelName = "MiDaS-GPU"; break;
+                    case 3: modelName = "MiDaS-HQ"; break;
+                    default: modelName = "MiDaS"; break;
+                }
+                Log.d(TAG, "Inference: " + duration + "ms (" + modelName + ")");
             }
         });
     }
@@ -179,7 +298,7 @@ public class DepthEstimator {
         tfliteMidas.run(inputBufferMidas, outputBufferMidas);
         outputBufferMidas.rewind();
 
-        return postProcess(outputBufferMidas, OUTPUT_SIZE);
+        return postProcess(outputBufferMidas, OUTPUT_SIZE, true);
     }
 
     private byte[] runInferenceDA(byte[] rgbaPixels, int width, int height) {
@@ -206,47 +325,184 @@ public class DepthEstimator {
         tfliteDepthAnything.run(inputBufferDA, outputBufferDA);
         outputBufferDA.rewind();
 
-        return postProcess(outputBufferDA, DA_INPUT_SIZE);
+        return postProcess(outputBufferDA, DA_INPUT_SIZE, true);
     }
 
-    private byte[] postProcess(ByteBuffer output, int size) {
+    private byte[] runInferenceMidasGpu(byte[] rgbaPixels, int width, int height) {
+        inputBufferGpu.rewind();
+        outputBufferGpu.rewind();
+
+        int srcRowBytes = width * 4;
+        float scaleX = (float) width / GPU_INPUT_SIZE;
+        float scaleY = (float) height / GPU_INPUT_SIZE;
+
+        for (int y = 0; y < GPU_INPUT_SIZE; y++) {
+            int srcY = Math.min((int) (y * scaleY), height - 1);
+            int srcRowOff = srcY * srcRowBytes;
+            for (int x = 0; x < GPU_INPUT_SIZE; x++) {
+                int srcX = Math.min((int) (x * scaleX), width - 1);
+                int srcIdx = srcRowOff + srcX * 4;
+                inputBufferGpu.putFloat((rgbaPixels[srcIdx] & 0xFF) / 255.0f);
+                inputBufferGpu.putFloat((rgbaPixels[srcIdx + 1] & 0xFF) / 255.0f);
+                inputBufferGpu.putFloat((rgbaPixels[srcIdx + 2] & 0xFF) / 255.0f);
+            }
+        }
+        inputBufferGpu.rewind();
+
+        tfliteMidasGpu.run(inputBufferGpu, outputBufferGpu);
+        outputBufferGpu.rewind();
+
+        // No dilate/blur here - the warp shader does its own edge-aware joint
+        // bilateral upsample against the actual color frame (stereo_screen.gdshader,
+        // stereo_mode 5), which snaps depth to real edges instead of averaging
+        // small objects (taskbar icons, widgets) away like the CPU blur below does.
+        return postProcess(outputBufferGpu, GPU_INPUT_SIZE, false);
+    }
+
+    // Same model weights as runInferenceMidas() (mode 0), but via the separate
+    // tfliteMidasHq NNAPI instance, feeding stereo_mode 6's warp pipeline. No
+    // dilate/blur here either, for the same reason as runInferenceMidasGpu() above -
+    // this is model-independent, not specific to which delegate produced the depth.
+    private byte[] runInferenceMidasHq(byte[] rgbaPixels, int width, int height) {
+        inputBufferHq.rewind();
+        outputBufferHq.rewind();
+
+        int srcRowBytes = width * 4;
+        float scaleX = (float) width / HQ_INPUT_SIZE;
+        float scaleY = (float) height / HQ_INPUT_SIZE;
+
+        for (int y = 0; y < HQ_INPUT_SIZE; y++) {
+            int srcY = Math.min((int) (y * scaleY), height - 1);
+            int srcRowOff = srcY * srcRowBytes;
+            for (int x = 0; x < HQ_INPUT_SIZE; x++) {
+                int srcX = Math.min((int) (x * scaleX), width - 1);
+                int srcIdx = srcRowOff + srcX * 4;
+                inputBufferHq.putFloat((rgbaPixels[srcIdx] & 0xFF) / 255.0f);
+                inputBufferHq.putFloat((rgbaPixels[srcIdx + 1] & 0xFF) / 255.0f);
+                inputBufferHq.putFloat((rgbaPixels[srcIdx + 2] & 0xFF) / 255.0f);
+            }
+        }
+        inputBufferHq.rewind();
+
+        tfliteMidasHq.run(inputBufferHq, outputBufferHq);
+        outputBufferHq.rewind();
+
+        return postProcess(outputBufferHq, HQ_INPUT_SIZE, false);
+    }
+
+    // Ported from Gilleece/moonlight-android-xr's xr_renderer.c
+    // nativeUploadDepth()/robustRange(): literal per-frame min/max lets a
+    // single stray pixel own the whole mapping - on one of their measured
+    // frames the 2nd..98th percentile span was only 638 of an 805-wide
+    // min/max range, meaning a fifth of the usable 0..1 depth range was
+    // being spent on a handful of outlier pixels instead of the actual
+    // scene. Our old code did exactly that (literal min/max), and did it
+    // TWICE (once on the raw model output, again on the already-smoothed
+    // result), compounding the loss - this was very likely the dominant
+    // cause of the depth effect measuring "shallow" even after the warp
+    // itself got fixed, more so than the parallax constant.
+    private static final int HIST_BINS = 512;
+    // How fast the normalization RANGE itself (smoothLo/smoothHi) and the
+    // final per-texel depth values (in temporalSmooth) track new inferences.
+    // Matches their own tuned defaults (rangeAlpha/depthAlpha) - range moves
+    // slowly so the mapping doesn't jump when the scene changes, texels
+    // move faster since they're already normalized into a stable band by
+    // that point.
+    private static final float RANGE_ALPHA = 0.15f;
+    private static final float DEPTH_ALPHA = 0.60f;
+    private float smoothLo = 0.0f;
+    private float smoothHi = 1.0f;
+    private boolean rangeValid = false;
+
+    private byte[] postProcess(ByteBuffer output, int size, boolean dilateAndBlur) {
         output.rewind();
         FloatBuffer floatOut = output.asFloatBuffer();
-        float min = Float.MAX_VALUE, max = Float.MIN_VALUE;
-        for (int i = 0; i < floatOut.capacity(); i++) {
-            float v = floatOut.get(i);
-            if (v < min) min = v;
-            if (v > max) max = v;
+        int count = size * size;
+        float[] raw = new float[count];
+        for (int i = 0; i < count; i++) {
+            raw[i] = floatOut.get(i);
         }
 
-        float range = max - min;
-        float[] rawDepth = new float[size * size];
-        if (range > 0) {
-            floatOut.rewind();
-            for (int i = 0; i < floatOut.capacity(); i++) {
-                rawDepth[i] = (floatOut.get() - min) / range;
-            }
+        float[] loHi = robustRange(raw, count);
+        if (!rangeValid) {
+            smoothLo = loHi[0];
+            smoothHi = loHi[1];
+            rangeValid = true;
+        } else {
+            smoothLo += RANGE_ALPHA * (loHi[0] - smoothLo);
+            smoothHi += RANGE_ALPHA * (loHi[1] - smoothHi);
+        }
+        float scale = 1.0f / Math.max(smoothHi - smoothLo, 1e-6f);
+
+        float[] normalized = new float[count];
+        for (int i = 0; i < count; i++) {
+            float v = (raw[i] - smoothLo) * scale;
+            normalized[i] = Math.max(0.0f, Math.min(1.0f, v));
         }
 
-        float[] dilated = dilate(rawDepth, size, 6);
-        float[] blurred = separableBoxBlur(dilated, size, 14);
-        float[] smoothed = temporalSmooth(blurred, size);
-
-        byte[] depthBytes = new byte[size * size];
-        float sMin = Float.MAX_VALUE, sMax = Float.MIN_VALUE;
-        for (int i = 0; i < smoothed.length; i++) {
-            if (smoothed[i] < sMin) sMin = smoothed[i];
-            if (smoothed[i] > sMax) sMax = smoothed[i];
+        float[] preSmooth = normalized;
+        if (dilateAndBlur) {
+            float[] dilated = dilate(normalized, size, 6);
+            preSmooth = separableBoxBlur(dilated, size, 14);
         }
-        float sRange = sMax - sMin;
-        if (sRange > 0) {
-            for (int i = 0; i < smoothed.length; i++) {
-                float normalized = (smoothed[i] - sMin) / sRange;
-                depthBytes[i] = (byte) (normalized * 255.0f);
-            }
-        }
+        float[] smoothed = temporalSmooth(preSmooth, size);
 
+        byte[] depthBytes = new byte[count];
+        for (int i = 0; i < count; i++) {
+            float v = Math.max(0.0f, Math.min(1.0f, smoothed[i]));
+            depthBytes[i] = (byte) (v * 255.0f);
+        }
         return depthBytes;
+    }
+
+    // 2nd and 98th percentile of the model output, via a histogram - see the
+    // postProcess() comment above for why this replaces literal min/max.
+    private float[] robustRange(float[] v, int count) {
+        float lo = v[0], hi = v[0];
+        for (int i = 1; i < count; i++) {
+            if (v[i] < lo) lo = v[i];
+            if (v[i] > hi) hi = v[i];
+        }
+        if (hi <= lo) {
+            return new float[]{lo, lo + 1.0f};
+        }
+
+        int[] hist = new int[HIST_BINS];
+        float binScale = HIST_BINS / (hi - lo);
+        for (int i = 0; i < count; i++) {
+            int b = (int) ((v[i] - lo) * binScale);
+            if (b < 0) b = 0;
+            if (b >= HIST_BINS) b = HIST_BINS - 1;
+            hist[b]++;
+        }
+
+        int loTarget = (int) (count * 0.02f);
+        int hiTarget = (int) (count * 0.98f);
+        int acc = 0;
+        int loBin = 0, hiBin = HIST_BINS - 1;
+        for (int b = 0; b < HIST_BINS; b++) {
+            acc += hist[b];
+            if (acc >= loTarget) {
+                loBin = b;
+                break;
+            }
+        }
+        acc = 0;
+        for (int b = 0; b < HIST_BINS; b++) {
+            acc += hist[b];
+            if (acc >= hiTarget) {
+                hiBin = b;
+                break;
+            }
+        }
+
+        float binWidth = (hi - lo) / HIST_BINS;
+        float robustLo = lo + loBin * binWidth;
+        float robustHi = lo + (hiBin + 1) * binWidth;
+        if (robustHi <= robustLo) {
+            robustHi = robustLo + 1e-3f;
+        }
+        return new float[]{robustLo, robustHi};
     }
 
     private float[] dilate(float[] depth, int size, int radius) {
@@ -312,48 +568,28 @@ public class DepthEstimator {
         return result;
     }
 
+    // Fixed-rate per-texel EMA, matching their depthAlpha - values entering
+    // here are already normalized into a stable [0,1] band by postProcess()'s
+    // robust+smoothed range, so a simple fixed blend is enough. The previous
+    // version instead measured how much the WHOLE frame changed and picked
+    // a smoothing amount from that, which could hit exactly zero on a fully
+    // static desktop (the common case) and permanently freeze the entire
+    // depth map at whatever one inference produced - small/ambiguous static
+    // elements (a clock widget, a subtly-3D background) that happened to
+    // get a weak first estimate stayed weak forever. A fixed rate never
+    // freezes, so it keeps denoising even when nothing on screen is moving.
     private float[] temporalSmooth(float[] newDepth, int size) {
         int len = size * size;
         if (smoothedDepthFloat == null) {
             smoothedDepthFloat = newDepth.clone();
-            previousDepthBytes = new byte[len];
-            for (int i = 0; i < len; i++) {
-                previousDepthBytes[i] = (byte) (newDepth[i] * 255.0f);
-            }
             return newDepth;
-        }
-
-        double totalDiff = 0.0;
-        double totalSqDiff = 0.0;
-        for (int i = 0; i < len; i++) {
-            float oldVal = (previousDepthBytes[i] & 0xFF) / 255.0f;
-            float diff = newDepth[i] - oldVal;
-            totalDiff += Math.abs(diff);
-            totalSqDiff += diff * diff;
-        }
-        double meanDiff = totalDiff / len;
-        double stdDev = Math.sqrt(totalSqDiff / len - meanDiff * meanDiff);
-        double depthDiff = Math.max(meanDiff, stdDev);
-
-        float smoothing;
-        if (depthDiff > 0.1) {
-            smoothing = 1.0f;
-        } else if (depthDiff > 0.01) {
-            smoothing = (float) (depthDiff * 2.0);
-            smoothing = Math.min(smoothing, 1.0f);
-        } else {
-            smoothing = 0.0f;
         }
 
         float[] result = new float[len];
         for (int i = 0; i < len; i++) {
             float prev = smoothedDepthFloat[i];
             float curr = newDepth[i];
-            result[i] = prev * (1.0f - smoothing) + curr * smoothing;
-        }
-
-        for (int i = 0; i < len; i++) {
-            previousDepthBytes[i] = (byte) (newDepth[i] * 255.0f);
+            result[i] = prev + DEPTH_ALPHA * (curr - prev);
         }
         smoothedDepthFloat = result;
 
@@ -368,6 +604,18 @@ public class DepthEstimator {
         if (tfliteDepthAnything != null) {
             tfliteDepthAnything.close();
             tfliteDepthAnything = null;
+        }
+        if (tfliteMidasGpu != null) {
+            tfliteMidasGpu.close();
+            tfliteMidasGpu = null;
+        }
+        if (gpuDelegateMidasGpu != null) {
+            gpuDelegateMidasGpu.close();
+            gpuDelegateMidasGpu = null;
+        }
+        if (tfliteMidasHq != null) {
+            tfliteMidasHq.close();
+            tfliteMidasHq = null;
         }
         activeInterpreter = null;
         initialized = false;

--- a/build.sh
+++ b/build.sh
@@ -185,8 +185,7 @@ cp android/src/main/java/com/godot/game/DepthEstimator.java android/build/src/ma
 mkdir -p android/build/nightfallAssets
 cp "$SCRIPT_DIR/android/src/main/assets/midas-midas-v2-w8a8.tflite" android/build/nightfallAssets/
 cp "$SCRIPT_DIR/android/src/main/assets/depth-anything-v2-small.tflite" android/build/nightfallAssets/ 2>/dev/null || true
-cp "$SCRIPT_DIR/android/src/main/assets/midas_v21_small_256_fp16.tflite" android/build/nightfallAssets/ 2>/dev/null || true
-sed -i '/implementation "androidx.documentfile:documentfile/a\\n    implementation "org.tensorflow:tensorflow-lite:2.16.1"\n    implementation "org.tensorflow:tensorflow-lite-gpu:2.16.1"\n    implementation "org.tensorflow:tensorflow-lite-gpu-api:2.16.1"' android/build/build.gradle
+sed -i '/implementation "androidx.documentfile:documentfile/a\\n    implementation "org.tensorflow:tensorflow-lite:2.16.1"' android/build/build.gradle
 sed -i "s|main.res.srcDirs += \['res'\]|main.res.srcDirs += ['res']\n        main.assets.srcDirs += ['nightfallAssets']|" android/build/build.gradle
 # mmap'd via AssetManager.openFd() at runtime (DepthEstimator.java), which requires
 # the entry be stored uncompressed in the APK

--- a/build.sh
+++ b/build.sh
@@ -175,10 +175,22 @@ cp "$SCRIPT_DIR/addons/nightfall-stream/bin/android/libgodot_android.so" libs/de
 cd "$SCRIPT_DIR"
 cp android/src/main/java/com/godot/game/GodotApp.java android/build/src/main/java/com/godot/game/GodotApp.java
 cp android/src/main/java/com/godot/game/DepthEstimator.java android/build/src/main/java/com/godot/game/DepthEstimator.java
-mkdir -p android/build/src/main/assets
-cp "$SCRIPT_DIR/android/src/main/assets/midas-midas-v2-w8a8.tflite" android/build/src/main/assets/
-cp "$SCRIPT_DIR/android/src/main/assets/depth-anything-v2-small.tflite" android/build/src/main/assets/ 2>/dev/null || true
-sed -i '/implementation "androidx.documentfile:documentfile/a\\n    implementation "org.tensorflow:tensorflow-lite:2.16.1"' android/build/build.gradle
+# Godot's own Android export always wipes and repopulates src/main/assets from
+# scratch right before invoking gradle (EditorExportPlatformAndroid::_clear_assets_directory(),
+# platform/android/export/export_plugin.cpp) - it's the directory Godot writes its own
+# project pck data into, so anything staged there before export() runs is deleted
+# regardless of ordering. Gradle's own asset merge (mergeDebugAssets/mergeReleaseAssets)
+# supports multiple source directories per source set though, so a sibling directory
+# declared via sourceSets below survives untouched and still gets merged into the APK.
+mkdir -p android/build/nightfallAssets
+cp "$SCRIPT_DIR/android/src/main/assets/midas-midas-v2-w8a8.tflite" android/build/nightfallAssets/
+cp "$SCRIPT_DIR/android/src/main/assets/depth-anything-v2-small.tflite" android/build/nightfallAssets/ 2>/dev/null || true
+cp "$SCRIPT_DIR/android/src/main/assets/midas_v21_small_256_fp16.tflite" android/build/nightfallAssets/ 2>/dev/null || true
+sed -i '/implementation "androidx.documentfile:documentfile/a\\n    implementation "org.tensorflow:tensorflow-lite:2.16.1"\n    implementation "org.tensorflow:tensorflow-lite-gpu:2.16.1"\n    implementation "org.tensorflow:tensorflow-lite-gpu-api:2.16.1"' android/build/build.gradle
+sed -i "s|main.res.srcDirs += \['res'\]|main.res.srcDirs += ['res']\n        main.assets.srcDirs += ['nightfallAssets']|" android/build/build.gradle
+# mmap'd via AssetManager.openFd() at runtime (DepthEstimator.java), which requires
+# the entry be stored uncompressed in the APK
+sed -i '/ignoreAssetsPattern/a\            noCompress "tflite"' android/build/build.gradle
 if [ "$PRESET" = "NightfallDev" ]; then
   mkdir -p android/build/libs/debug
   cp "$SCRIPT_DIR/addons/godotopenxrvendors/.bin/android/debug/godotopenxr-meta-debug.aar" android/build/libs/debug/ 2>/dev/null || true

--- a/main.gd
+++ b/main.gd
@@ -1115,7 +1115,7 @@ func _init_android_setup():
 		_prepare_fade_materials("right")
 		_prepare_fade_materials("left")
 	sbs_mode = clampi(sbs_mode, 0, 2)
-	ai_3d_mode = clampi(ai_3d_mode, 0, 4)
+	ai_3d_mode = clampi(ai_3d_mode, 0, 6)
 
 	if right_hand and left_hand:
 		var right_ray = right_hand.get_node_or_null("HandRayCast")

--- a/main.gd
+++ b/main.gd
@@ -67,7 +67,12 @@ var _did_initial_monitor_trim: bool = false
 var _stream_start_seq: int = 0
 var is_streaming: bool = false
 var sbs_mode: int = 0
-var ai_3d_mode: int = 0
+# Split (2026-08-18) from a single flat ai_3d_mode into three independent
+# axes - see settings_controller.gd's ai_3d_model_labels/ai_3d_quality_labels/
+# ai_3d_debug_labels and get_stereo_mode() for how they combine.
+var ai_3d_model: int = 0 # 0=Off, 1=MiDaS
+var ai_3d_quality: int = 0 # 0=Auto, 1=Fastest, 2=Fast, 3=Standard
+var ai_3d_debug: int = 0 # 0=Off, 1=DMap, 2=DMap-Raw, 3=DMap-Input
 var is_xr_active: bool = false
 var was_clicking: bool = false
 var was_right_clicking: bool = false
@@ -373,6 +378,8 @@ var _ui_grid_mode_btn: Button
 var _ui_hand_tracking_btn: Button
 var _ui_sbs_btn: Button
 var _ui_3d_btn: Button
+var _ui_3d_quality_btn: Button
+var _ui_3d_debug_btn: Button
 var _ui_res_btn: Button
 var _ui_fps_btn: Button
 var _ui_bitrate_btn: Button
@@ -541,8 +548,9 @@ func compute_requested_resolution(apply_midas_cap: bool = true) -> Vector2i:
 			h = int(h * scale)
 	# MiDaS-Fast/-Fastest only - see MIDAS_FAST_MAX_PIXELS's comment above.
 	# Keyed off the actually-active stereo mode (accounts for sbs_mode
-	# overriding ai_3d_mode, same as settings_controller.get_stereo_mode()
-	# itself), not raw ai_3d_mode. Caps by total pixel budget (like
+	# overriding ai_3d_model/quality/debug, same as
+	# settings_controller.get_stereo_mode() itself), not those raw fields
+	# directly. Caps by total pixel budget (like
 	# HEVC_MAX_TOTAL_PIXELS above), NOT a width/height pair scaled by
 	# min(target_w/w, target_h/h) - that approach silently deliverd far
 	# fewer pixels than intended on a non-16:9 source (see history above).
@@ -1180,7 +1188,9 @@ func _init_android_setup():
 		_prepare_fade_materials("right")
 		_prepare_fade_materials("left")
 	sbs_mode = clampi(sbs_mode, 0, 2)
-	ai_3d_mode = clampi(ai_3d_mode, 0, 6)
+	ai_3d_model = clampi(ai_3d_model, 0, 1)
+	ai_3d_quality = clampi(ai_3d_quality, 0, 3)
+	ai_3d_debug = clampi(ai_3d_debug, 0, 3)
 
 	if right_hand and left_hand:
 		var right_ray = right_hand.get_node_or_null("HandRayCast")
@@ -1643,7 +1653,7 @@ func _init_xr(interface):
 	if interface.has_signal("user_presence_changed"):
 		interface.user_presence_changed.connect(_on_user_presence_changed)
 	sbs_mode = 0
-	ai_3d_mode = 0
+	ai_3d_model = 0
 
 	settings_controller.apply_display_refresh_rate()
 
@@ -1769,7 +1779,7 @@ func _process(delta):
 
 	if depth_estimator:
 		depth_estimator.process(delta)
-		if depth_estimator.depth_texture and ai_3d_mode > 0 and comp.in_use:
+		if depth_estimator.depth_texture and ai_3d_model > 0 and comp.in_use:
 			var dt = depth_estimator.depth_texture
 			if comp_shader_mat_left and not comp_shader_mat_left.get_shader_parameter("depth_texture"):
 				comp_shader_mat_left.set_shader_parameter("depth_texture", dt)

--- a/main.gd
+++ b/main.gd
@@ -443,6 +443,25 @@ const HEVC_MAX_TOTAL_PIXELS = 35389440
 # (80% of that specific 4-monitor test), not a round-number guess.
 const HEVC_MAX_SUSTAINED_PIXELS = 21233664
 
+# Extra resolution ceilings applied only while MiDaS-Fast/-Fastest are the
+# active stereo mode (2026-08-18) - unlike every knob AI-3D's own pipeline
+# exposes (pre-pass resolution/throttle, Newton-refinement cadence, depth-
+# capture throttle), none of which moved FPS at 4K when tested, capping the
+# actual decoded/composited stream size directly attacks the real cost:
+# general per-pixel video decode + compositing work, which scales with
+# resolution regardless of AI-3D. MiDaS-Std is intentionally NOT capped here -
+# it stays the uncapped/known-good reference. See compute_requested_resolution().
+# Confirmed on-device (2026-08-18): 3200x1800 runs MiDaS-Fast stutter-free
+# without passthrough; 2560x1440 runs MiDaS-Fastest stutter-free WITH
+# passthrough on (the extra passthrough compositing cost is why Fastest's
+# cap is the lower of the two). 3456x1944 also held up for Fast, so pushed
+# a bit further; 2816x1584 introduced slight stutter for Fastest, so that
+# one's back down to the last confirmed-good 2560x1440 rather than pushed
+# further - Fastest is protected/conservative, Fast is the one still being
+# probed for its ceiling.
+const MIDAS_FAST_MAX_RES := Vector2i(3712, 2088)
+const MIDAS_FASTEST_MAX_RES := Vector2i(2560, 1440)
+
 # The highest resolution_scale_pct that keeps compute_requested_resolution()'s
 # result under every constraint that applies to the given codec at the
 # current native_resolution, i.e. the point past which compute_requested_resolution()
@@ -510,6 +529,21 @@ func compute_requested_resolution() -> Vector2i:
 		if scale < 1.0:
 			w = int(w * scale)
 			h = int(h * scale)
+	# MiDaS-Fast/-Fastest only - see MIDAS_FAST_MAX_RES's comment above.
+	# Keyed off the actually-active stereo mode (accounts for sbs_mode
+	# overriding ai_3d_mode, same as settings_controller.get_stereo_mode()
+	# itself), not raw ai_3d_mode.
+	if settings_controller:
+		var stereo_mode = settings_controller.get_stereo_mode()
+		var res_cap := Vector2i.ZERO
+		if stereo_mode == 10:
+			res_cap = MIDAS_FAST_MAX_RES
+		elif stereo_mode == 11:
+			res_cap = MIDAS_FASTEST_MAX_RES
+		if res_cap != Vector2i.ZERO and (w > res_cap.x or h > res_cap.y):
+			var cap_scale = minf(float(res_cap.x) / w, float(res_cap.y) / h)
+			w = int(w * cap_scale)
+			h = int(h * cap_scale)
 	w = maxi(w - (w % 2), 320)
 	h = maxi(h - (h % 2), 180)
 	return Vector2i(w, h)
@@ -1115,7 +1149,7 @@ func _init_android_setup():
 		_prepare_fade_materials("right")
 		_prepare_fade_materials("left")
 	sbs_mode = clampi(sbs_mode, 0, 2)
-	ai_3d_mode = clampi(ai_3d_mode, 0, 5)
+	ai_3d_mode = clampi(ai_3d_mode, 0, 6)
 
 	if right_hand and left_hand:
 		var right_ray = right_hand.get_node_or_null("HandRayCast")

--- a/main.gd
+++ b/main.gd
@@ -1115,7 +1115,7 @@ func _init_android_setup():
 		_prepare_fade_materials("right")
 		_prepare_fade_materials("left")
 	sbs_mode = clampi(sbs_mode, 0, 2)
-	ai_3d_mode = clampi(ai_3d_mode, 0, 6)
+	ai_3d_mode = clampi(ai_3d_mode, 0, 5)
 
 	if right_hand and left_hand:
 		var right_ray = right_hand.get_node_or_null("HandRayCast")

--- a/main.gd
+++ b/main.gd
@@ -552,7 +552,7 @@ func compute_requested_resolution(apply_midas_cap: bool = true) -> Vector2i:
 	# settings_controller.get_stereo_mode() itself), not those raw fields
 	# directly. Caps by total pixel budget (like
 	# HEVC_MAX_TOTAL_PIXELS above), NOT a width/height pair scaled by
-	# min(target_w/w, target_h/h) - that approach silently deliverd far
+	# min(target_w/w, target_h/h) - that approach silently delivered far
 	# fewer pixels than intended on a non-16:9 source (see history above).
 	# apply_midas_cap=false lets a caller ask "what would this resolution be
 	# WITHOUT the AI-3D cap" - see stream_manager.gd's start_stream(), which

--- a/main.gd
+++ b/main.gd
@@ -633,6 +633,18 @@ func _update_cursor_layer():
 			comp_cursor.visible = false
 			_hide_all_stream_cursors()
 		elif use_in_stream and on_screen:
+			# Only hovered_screen gets shown below - explicitly hide every other
+			# screen's cursor the instant the hover target changes, rather than
+			# leaving whichever screen was PREVIOUSLY hovered showing its last
+			# cursor position until something else happens to call
+			# _hide_all_stream_cursors() (e.g. the ray briefly leaving every
+			# screen entirely) - that gap is what let two cursors show at once
+			# when moving straight from one screen to another.
+			for s in screens:
+				if s != hovered_screen:
+					_hide_stream_cursor(s.comp_stream_cursor, s.comp_stream_cursor_circle)
+					_hide_stream_cursor(s.comp_stream_cursor_left, s.comp_stream_cursor_circle_left)
+					_hide_stream_cursor(s.comp_stream_cursor_right, s.comp_stream_cursor_circle_right)
 			var uv = hovered_screen.hit_point_to_uv(hit_point)
 			var bezel_px = 8 if bezel_enabled else 0
 			var base_w = hovered_screen.comp_base_size.x
@@ -648,7 +660,18 @@ func _update_cursor_layer():
 			_show_stream_cursor(hovered_screen.comp_stream_cursor, hovered_screen.comp_stream_cursor_circle, cx, cy, cursor_px)
 			if stereo > 0 and hovered_screen == primary_screen:
 				var left_cx = cx
-				if stereo >= 3:
+				if stereo == 5 or stereo == 6:
+					# This hand-tuned pop was calibrated against the old, much
+					# weaker mode 3/4 warp (parallax ~0.042) - scaled down by
+					# the same ratio for modes 5/6's real, calibrated parallax
+					# (depth_estimator.gd's _pass_parallax, ~0.006) rather
+					# than reused verbatim, or the cursor pops far more than
+					# anything actually in the depth-warped video. Both modes
+					# share the exact same warp pipeline/parallax magnitude -
+					# only the depth model backing them differs (GPU delegate
+					# vs NNAPI, see DepthEstimator.java).
+					left_cx += (0.015 / 0.042) * depth_estimator._pass_parallax * base_w
+				elif stereo >= 3:
 					left_cx += 0.015 * base_w
 				_show_stream_cursor(hovered_screen.comp_stream_cursor_left, hovered_screen.comp_stream_cursor_circle_left, left_cx, cy, cursor_px)
 				_show_stream_cursor(hovered_screen.comp_stream_cursor_right, hovered_screen.comp_stream_cursor_circle_right, cx, cy, cursor_px)
@@ -1076,13 +1099,23 @@ func _init_modules():
 
 func _init_android_setup():
 	if OS.get_name() == "Android":
+		# Must run BEFORE _init_backgrounds_and_comp_layer() creates
+		# comp_viewport_left/right - depth_estimator's upsample/offset
+		# SubViewports (stereo_mode 5) produce the warp data those actually-
+		# displayed per-eye viewports consume every frame (via
+		# yuv_display.gdshader), and Godot updates SubViewports in scene-tree
+		# order, so the producer must be added to the tree first. (The
+		# upsample pass used to also depend on comp_viewport - the OPPOSITE
+		# direction - which was the real source of a stutter/double-image
+		# bug; that dependency was removed by having it decode YUV directly
+		# instead, see depth_upsample.gdshader.)
 		depth_estimator.setup()
 		Input.mouse_mode = Input.MOUSE_MODE_CAPTURED
 		_load_controller_models()
 		_prepare_fade_materials("right")
 		_prepare_fade_materials("left")
 	sbs_mode = clampi(sbs_mode, 0, 2)
-	ai_3d_mode = clampi(ai_3d_mode, 0, 1)
+	ai_3d_mode = clampi(ai_3d_mode, 0, 4)
 
 	if right_hand and left_hand:
 		var right_ray = right_hand.get_node_or_null("HandRayCast")
@@ -1529,10 +1562,33 @@ func _init_xr(interface):
 		get_viewport().msaa_3d = Viewport.MSAA_2X
 	_xr_base_render_scale = get_viewport().scaling_3d_scale
 	is_xr_active = true
+	# Godot's own comp-layer/texture bindings (connect_welcome_texture() et al)
+	# only ever run once, here at boot, regardless of whether the OpenXR
+	# session is actually visible yet - is_initialized() (checked before this
+	# function is even called) only means a session exists, not that the
+	# headset is being worn: the proximity sensor is a separate state Quest
+	# tracks independently of session creation. Launching headlessly (e.g. via
+	# adb) and only putting the headset on afterward left the welcome screen
+	# showing its plain grey placeholder texture, because nothing ever
+	# re-touched the binding once the session actually became visible.
+	# user_presence_changed is the proximity-sensor signal itself - re-run the
+	# one-time welcome-texture binding whenever the headset is (re-)donned,
+	# which is cheap and idempotent, so it's safe even on a session that was
+	# already correctly bound.
+	if interface.has_signal("user_presence_changed"):
+		interface.user_presence_changed.connect(_on_user_presence_changed)
 	sbs_mode = 0
 	ai_3d_mode = 0
 
 	settings_controller.apply_display_refresh_rate()
+
+func _on_user_presence_changed(is_present: bool):
+	# Only the welcome screen depends on this - once actually streaming, the
+	# real video texture bindings are already refreshed by their own paths
+	# (_on_stream_started() et al) and re-running connect_welcome_texture()
+	# here would incorrectly stomp them back to the welcome viewport.
+	if is_present and comp and comp.available and not is_streaming:
+		comp.connect_welcome_texture()
 
 func _init_backgrounds_and_comp_layer():
 	_create_backgrounds()
@@ -1628,9 +1684,6 @@ func _process(delta):
 
 	if Engine.get_frames_drawn() % 120 == 0:
 		_flush_log()
-
-	if comp:
-		comp.process_loading_dots(delta)
 
 	_process_button_input()
 

--- a/main.gd
+++ b/main.gd
@@ -451,16 +451,26 @@ const HEVC_MAX_SUSTAINED_PIXELS = 21233664
 # general per-pixel video decode + compositing work, which scales with
 # resolution regardless of AI-3D. MiDaS-Std is intentionally NOT capped here -
 # it stays the uncapped/known-good reference. See compute_requested_resolution().
-# Confirmed on-device (2026-08-18): 3200x1800 runs MiDaS-Fast stutter-free
-# without passthrough; 2560x1440 runs MiDaS-Fastest stutter-free WITH
-# passthrough on (the extra passthrough compositing cost is why Fastest's
-# cap is the lower of the two). 3456x1944 also held up for Fast, so pushed
-# a bit further; 2816x1584 introduced slight stutter for Fastest, so that
-# one's back down to the last confirmed-good 2560x1440 rather than pushed
-# further - Fastest is protected/conservative, Fast is the one still being
-# probed for its ceiling.
-const MIDAS_FAST_MAX_RES := Vector2i(3712, 2088)
-const MIDAS_FASTEST_MAX_RES := Vector2i(2560, 1440)
+#
+# History: capped both tiers, then MiDaS-Fast/-Fastest's 3D quality looked
+# visibly worse than MiDaS-Std. [DEPTH]-tagged logging in depth_estimator.gd
+# ruled out the depth pipeline itself (capture/submission/polling equally
+# healthy across all tiers) and the bitrate cliff bug (fixed separately,
+# stream_manager.gd's _auto_bitrate() now scales from the UNCAPPED
+# resolution). Root cause found 2026-08-18: these caps were width/height
+# pairs, aspect-scaled with min(target_w/w, target_h/h) - on a WIDE source
+# (native_resolution here is a 2.96:1 multi-monitor composite, not 16:9),
+# the width dimension binds first, so "cap to 2560x1440" actually produced
+# 2560x864 (2.21M px) instead of the 3.69M px the "1440p" label implied -
+# confirmed directly: manually selecting 1440p and letting Fastest's cap
+# reduce down to "1440p" were NOT delivering the same pixel count at all,
+# despite looking like they should be equal. Fixed by capping to a total
+# PIXEL BUDGET via sqrt(target_px/actual_px) instead of a width/height pair
+# - same approach this file already uses for HEVC_MAX_TOTAL_PIXELS just
+# below, which doesn't have this problem because it already works in pixels.
+const MIDAS_RES_CAP_ENABLED := true
+const MIDAS_FAST_MAX_PIXELS := 3200 * 1800
+const MIDAS_FASTEST_MAX_PIXELS := 2560 * 1440
 
 # The highest resolution_scale_pct that keeps compute_requested_resolution()'s
 # result under every constraint that applies to the given codec at the
@@ -496,7 +506,7 @@ func compute_resolution_options() -> Array:
 			opts.append(p)
 	return opts
 
-func compute_requested_resolution() -> Vector2i:
+func compute_requested_resolution(apply_midas_cap: bool = true) -> Vector2i:
 	var w: int
 	var h: int
 	if is_polaris_host:
@@ -529,19 +539,27 @@ func compute_requested_resolution() -> Vector2i:
 		if scale < 1.0:
 			w = int(w * scale)
 			h = int(h * scale)
-	# MiDaS-Fast/-Fastest only - see MIDAS_FAST_MAX_RES's comment above.
+	# MiDaS-Fast/-Fastest only - see MIDAS_FAST_MAX_PIXELS's comment above.
 	# Keyed off the actually-active stereo mode (accounts for sbs_mode
 	# overriding ai_3d_mode, same as settings_controller.get_stereo_mode()
-	# itself), not raw ai_3d_mode.
-	if settings_controller:
+	# itself), not raw ai_3d_mode. Caps by total pixel budget (like
+	# HEVC_MAX_TOTAL_PIXELS above), NOT a width/height pair scaled by
+	# min(target_w/w, target_h/h) - that approach silently deliverd far
+	# fewer pixels than intended on a non-16:9 source (see history above).
+	# apply_midas_cap=false lets a caller ask "what would this resolution be
+	# WITHOUT the AI-3D cap" - see stream_manager.gd's start_stream(), which
+	# uses that to pick Auto bitrate from the uncapped resolution instead of
+	# the capped encode resolution (same bitrate, fewer pixels should mean
+	# MORE bits per pixel, not fewer).
+	if apply_midas_cap and MIDAS_RES_CAP_ENABLED and settings_controller:
 		var stereo_mode = settings_controller.get_stereo_mode()
-		var res_cap := Vector2i.ZERO
+		var max_pixels := 0
 		if stereo_mode == 10:
-			res_cap = MIDAS_FAST_MAX_RES
+			max_pixels = MIDAS_FAST_MAX_PIXELS
 		elif stereo_mode == 11:
-			res_cap = MIDAS_FASTEST_MAX_RES
-		if res_cap != Vector2i.ZERO and (w > res_cap.x or h > res_cap.y):
-			var cap_scale = minf(float(res_cap.x) / w, float(res_cap.y) / h)
+			max_pixels = MIDAS_FASTEST_MAX_PIXELS
+		if max_pixels > 0 and w * h > max_pixels:
+			var cap_scale = sqrt(float(max_pixels) / float(w * h))
 			w = int(w * cap_scale)
 			h = int(h * cap_scale)
 	w = maxi(w - (w % 2), 320)
@@ -851,7 +869,20 @@ func _on_stream_started():
 	# first real frame should have landed.
 	_stream_start_seq += 1
 	_retry_yuv_bind(_stream_start_seq)
-	_switch_to_comp_layer()
+	# Was an unconditional _switch_to_comp_layer() (plain/mono), which reset
+	# AI-3D/SBS to 2D on EVERY (re)connect, silently, with nothing re-
+	# applying the real mode afterward unless the user happened to touch a
+	# mode button again post-restart - root cause of "3D effect stopped
+	# working after a restart, only came back after manually cycling modes"
+	# (2026-08-18, user diagnosed this from watching a MiDaS-Fast switch
+	# visibly apply against the OLD pre-restart video, then get lost when
+	# the restart landed). apply_stereo() re-derives and applies the actual
+	# current stereo mode (2D/SBS/AI-3D) against the freshly (re)started
+	# session instead of blindly resetting to 2D - settings_controller.gd's
+	# _schedule_ai_3d_commit() now deliberately skips its own apply_stereo()
+	# call when a restart is about to happen, relying on this one instead,
+	# so the mode is only ever applied against a session that's actually live.
+	settings_controller.apply_stereo()
 	if not was_restarting:
 		ui_visible = false
 		_set_ui_visible(false)

--- a/src/auto_detect.gd
+++ b/src/auto_detect.gd
@@ -58,10 +58,10 @@ func run():
 		if val != detected_mode:
 			all_match = false
 			break
-	var current_sbs = main.sbs_mode if main.ai_3d_mode == 0 else 0
+	var current_sbs = main.sbs_mode if main.ai_3d_model == 0 else 0
 	if all_match and main.detection_history.size() >= 5 and detected_mode != current_sbs:
 		main.sbs_mode = detected_mode
-		main.ai_3d_mode = 0
+		main.ai_3d_model = 0
 		main.settings_controller.apply_stereo()
 		main.ui_controller.update_stereo_shader()
 	main.auto_detect_running = false

--- a/src/composition_layer_manager.gd
+++ b/src/composition_layer_manager.gd
@@ -197,14 +197,9 @@ func _make_yuv_rect() -> ColorRect:
 	return r
 
 const DOT_COLOR := Color(0.25, 0.25, 0.25)
-const DOT_HIDDEN_COLOR := Color(0.45, 0.45, 0.45)  # matches the placeholder/background grey, so a "hidden" dot just blends in
 const DOT_BASE_FONT_SIZE := 96
 const DOT_BASE_HEIGHT := 1080.0
 
-const DOT_ANIM_INTERVAL := 0.6
-
-var _dot_anim_time := 0.0
-var _dot_anim_phase := 1  # start on the center dot
 # A single "restart episode" (settings change -> teardown -> reconnect ->
 # possibly one more mismatch-retry reconnect, see main.gd's
 # _on_stream_started()) calls clear_yuv_textures() more than once before the
@@ -241,33 +236,6 @@ func _make_loading_dots() -> Dictionary:
 		hbox.add_child(d)
 		dots.append(d)
 	return {"container": container, "dots": dots}
-
-func _apply_dot_phase(dots: Array):
-	for i in range(dots.size()):
-		if dots[i]:
-			dots[i].add_theme_color_override("font_color", DOT_HIDDEN_COLOR if i == _dot_anim_phase else DOT_COLOR)
-
-# Called every frame from main._process(); cheap no-op unless a loading
-# indicator is actually visible somewhere.
-func process_loading_dots(delta: float):
-	var any_visible = false
-	for s in main.screens:
-		if (s.comp_loading_label and s.comp_loading_label.visible) \
-		or (s.comp_loading_label_left and s.comp_loading_label_left.visible) \
-		or (s.comp_loading_label_right and s.comp_loading_label_right.visible):
-			any_visible = true
-			break
-	if not any_visible:
-		return
-	_dot_anim_time += delta
-	if _dot_anim_time < DOT_ANIM_INTERVAL:
-		return
-	_dot_anim_time -= DOT_ANIM_INTERVAL
-	_dot_anim_phase = (_dot_anim_phase + 1) % 3
-	for s in main.screens:
-		_apply_dot_phase(s.comp_loading_dots)
-		_apply_dot_phase(s.comp_loading_dots_left)
-		_apply_dot_phase(s.comp_loading_dots_right)
 
 # The dots' font_size is in the comp SubViewport's own pixel space, which is
 # resized to the real stream resolution (resize_stream_viewport()) - without
@@ -634,6 +602,19 @@ func bind_comp_yuv_textures(tex_y, tex_u, tex_v, yuv_mode: int, cmt, cr):
 		for lbl in [s.comp_loading_label, s.comp_loading_label_left, s.comp_loading_label_right]:
 			if lbl:
 				lbl.visible = false
+	# stereo_mode 5's upsample pass decodes YUV itself now (depth_upsample.gdshader)
+	# rather than depending on comp_viewport's rendered output - see main.gd's
+	# depth_estimator.setup() call site for why that dependency direction was a
+	# problem. AI-3D is primary-only, so this always mirrors whatever the loop
+	# above just bound, regardless of which screen(s) it iterated.
+	if main.depth_estimator and main.depth_estimator.upsample_mat:
+		var um = main.depth_estimator.upsample_mat
+		um.set_shader_parameter("tex_y", tex_y)
+		um.set_shader_parameter("tex_u", tex_u)
+		um.set_shader_parameter("tex_v", tex_v)
+		um.set_shader_parameter("yuv_mode", yuv_mode)
+		um.set_shader_parameter("color_matrix_type", cmt)
+		um.set_shader_parameter("color_range", cr)
 	_dots_active = false
 	main._log("[COMP] YUV textures bound to composition layer shader (mode=%d)" % yuv_mode)
 
@@ -800,12 +781,6 @@ func clear_yuv_textures():
 	# _on_stream_started()) only does this once instead of re-sizing/resetting
 	# on every intermediate clear_yuv_textures() call in between.
 	update_loading_dot_sizes()
-	_dot_anim_time = 0.0
-	_dot_anim_phase = 1
-	for s in main.screens:
-		_apply_dot_phase(s.comp_loading_dots)
-		_apply_dot_phase(s.comp_loading_dots_left)
-		_apply_dot_phase(s.comp_loading_dots_right)
 
 static func set_grab_bar_color(viewport: SubViewport, color: Color):
 	if not viewport:

--- a/src/depth_estimator.gd
+++ b/src/depth_estimator.gd
@@ -25,6 +25,17 @@ var submit_timer: float = 0.0
 var submit_interval: float = 0.05
 var model_size: int = 256
 var _poll_timer: float = 0.0
+# Temporary (2026-08-18): confirms the depth pipeline is actually live -
+# capturing, submitting, and getting real (non-degenerate) depth data back -
+# while investigating why MiDaS-Fastest looks worse than Fast/Std even
+# though it's confirmed NOT a resolution difference. Logs once/sec via
+# main._log() (tag [DEPTH]), not every submit_interval tick, to stay
+# readable in logcat. Remove once the Fastest investigation is done.
+var _debug_log_timer: float = 0.0
+var _debug_last_submit_bytes: int = -1
+var _debug_last_poll_bytes: int = -1
+var _debug_last_poll_min: int = -1
+var _debug_last_poll_max: int = -1
 
 # stereo_mode 5/6 (MiDaS-GPU / MiDaS-Std)'s upsample+offset passes - see
 # depth_upsample.gdshader / depth_offset.gdshader for what these compute.
@@ -277,6 +288,7 @@ func set_enabled(val: bool, run_warp_passes: bool = false, warp_tier: int = 0):
 		2: _pass_divisor = FASTEST_PASS_DIVISOR
 		_: _pass_divisor = PASS_DIVISOR
 	_push_warp_newton_steps(2 if _warp_tier == 0 else 0)
+	main._log("[DEPTH] set_enabled val=%s run_warp_passes=%s warp_tier=%d pass_divisor=%d native_res=%s" % [str(val), str(run_warp_passes), _warp_tier, _pass_divisor, str(main.native_resolution)])
 	var mode: int = (SubViewport.UPDATE_ONCE if _warp_throttled else SubViewport.UPDATE_ALWAYS) if _warp_passes_active else SubViewport.UPDATE_DISABLED
 	if upsample_viewport:
 		upsample_viewport.render_target_update_mode = mode
@@ -312,8 +324,11 @@ func process(delta: float):
 			var img = depth_viewport.get_texture().get_image()
 			if img != null and not img.is_empty():
 				var data = img.get_data()
+				_debug_last_submit_bytes = data.size()
 				if data.size() > 0:
 					main.stream_backend.submit_depth_frame(data, model_size, model_size)
+			else:
+				_debug_last_submit_bytes = 0
 
 	if main.stream_backend.has_method("get_depth_map"):
 		_poll_timer += delta
@@ -323,3 +338,23 @@ func process(delta: float):
 			if depth_bytes != null and depth_bytes.size() == model_size * model_size:
 				var depth_image = Image.create_from_data(model_size, model_size, false, Image.FORMAT_L8, depth_bytes)
 				depth_texture.update(depth_image)
+				_debug_last_poll_bytes = depth_bytes.size()
+				var lo = 255
+				var hi = 0
+				for i in range(0, depth_bytes.size(), 17):
+					var v = depth_bytes[i]
+					if v < lo: lo = v
+					if v > hi: hi = v
+				_debug_last_poll_min = lo
+				_debug_last_poll_max = hi
+			else:
+				_debug_last_poll_bytes = depth_bytes.size() if depth_bytes != null else -1
+
+	# Temporary - see _debug_log_timer's comment above.
+	_debug_log_timer += delta
+	if _debug_log_timer >= 1.0:
+		_debug_log_timer = 0.0
+		var uv_region = upsample_mat.get_shader_parameter("uv_region") if upsample_mat else null
+		main._log("[DEPTH] tier=%d pass_size=%s submit_bytes=%d poll_bytes=%d poll_range=[%d,%d] uv_region=%s" % [
+			_warp_tier, str(_pass_size), _debug_last_submit_bytes, _debug_last_poll_bytes,
+			_debug_last_poll_min, _debug_last_poll_max, str(uv_region)])

--- a/src/depth_estimator.gd
+++ b/src/depth_estimator.gd
@@ -7,9 +7,50 @@ var depth_target: TextureRect
 var depth_texture: ImageTexture
 var enabled: bool = false
 var submit_timer: float = 0.0
-var submit_interval: float = 0.1
+# 20Hz, matching Gilleece/moonlight-android-xr's own cadence comment ("depth
+# arrives at about 20Hz") and their own tuned/shipped default - trusted as
+# measured rather than re-litigated here. A 10Hz middle ground was tried
+# after the JNI depth pipeline was fixed from being silently broken (see git
+# history around 2026-08-17) to rule out this cadence as the cause of
+# DMap detail loss / GPU-NNAPI stutter observed at 20Hz, but the user
+# confirmed on-device that 20Hz gives back full DMap detail (a clock widget
+# that had disappeared) - so the stutter and detail-loss symptoms are NOT
+# from this cadence. More likely cause: depth_upsample.gdshader /
+# depth_offset.gdshader's own per-render-frame warp passes (see
+# _setup_warp_passes() below), since baseline stereo_mode 3/4 (which skips
+# those passes entirely) stays smooth even though its own postProcess does
+# MORE CPU work per call via dilate+blur. That's the next thing to fix, not
+# this value.
+var submit_interval: float = 0.05
 var model_size: int = 256
 var _poll_timer: float = 0.0
+
+# stereo_mode 5/6 (MiDaS-GPU / MiDaS-NNAPI)'s upsample+offset passes - see
+# depth_upsample.gdshader / depth_offset.gdshader for what these compute.
+# Run once per frame, shared by both eyes, at a quarter of the stream's own
+# resolution (matches Gilleece/moonlight-android-xr's own upsampleWidth =
+# videoWidth/4) rather than at raw 256x256 or, worse, at full per-eye
+# resolution - the latter is what made the first attempt at this tank
+# performance, since the same expensive bilateral/search work was repeated
+# per eye per full-res pixel instead of once for the whole frame.
+const PASS_DIVISOR := 4
+const PASS_MIN_SIZE := 160
+var upsample_viewport: SubViewport
+var upsample_mat: ShaderMaterial
+var offset_viewport: SubViewport
+var offset_mat: ShaderMaterial
+# Matches Gilleece/moonlight-android-xr's own shipped default separation
+# (0.5% of frame width). Tested bumping this to 0.02 (~3.3x) on the theory
+# that magnitude was the remaining gap for why the depth effect still felt
+# weak overall despite edges (taskbar etc.) looking correct - on-device
+# testing found NO improvement at all, ruling magnitude out as the (sole)
+# cause. Something more fundamental is still missing; revisit before trying
+# magnitude again. See conversation history around 2026-08-17 for the full
+# investigation (occlusion search, robust-range normalization, letterboxing,
+# aliasing, render-order, and GPU-contention fixes all landed first and are
+# confirmed working - this is what's left after all of that).
+var _pass_parallax: float = 0.006
+var _pass_size: Vector2i = Vector2i.ZERO
 
 var _platform: String
 
@@ -31,20 +72,105 @@ func setup():
 	depth_target = TextureRect.new()
 	depth_target.name = "DepthTarget"
 	depth_target.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
-	depth_target.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	# Plain stretch-to-fill, NOT aspect-preserved: depth_texture is assumed
+	# to cover frame UV 0..1 1:1 everywhere else in the pipeline (the warp
+	# shaders index into it via tile_uv directly) - KEEP_ASPECT_CENTERED
+	# would letterbox a 16:9-ish stream into this square target, wasting a
+	# fifth of the model's input on empty margin AND silently breaking that
+	# 1:1 UV assumption for the entire frame, not just the edges.
+	# Gilleece/moonlight-android-xr's own downscale (DOWNSCALE_FRAGMENT_SRC)
+	# confirms this: a plain UV stretch with no aspect correction at all.
+	depth_target.stretch_mode = TextureRect.STRETCH_SCALE
 	depth_target.size = Vector2i(model_size, model_size)
 	depth_target.set_anchors_preset(Control.PRESET_FULL_RECT)
+	# The default filter is a single bilinear tap - for a ~10x reduction
+	# (e.g. 2560px stream -> model_size), that aliases badly, feeding MiDaS a
+	# noisier input than it needs. Gilleece/moonlight-android-xr does an
+	# explicit 4x4 box filter in a shader for exactly this
+	# (DOWNSCALE_FRAGMENT_SRC); mipmap filtering is Godot's built-in
+	# equivalent - the GPU picks/blends the right pre-averaged mip level
+	# instead of a single raw sample.
+	depth_target.texture_filter = CanvasItem.TEXTURE_FILTER_LINEAR_WITH_MIPMAPS
 	depth_viewport.add_child(depth_target)
 	main.add_child(depth_viewport)
 
 	var img = Image.create(model_size, model_size, false, Image.FORMAT_L8)
 	depth_texture = ImageTexture.create_from_image(img)
+
+	_setup_warp_passes()
+
 	if main.primary_screen and main.primary_screen.material_override is ShaderMaterial:
 		main.primary_screen.material_override.set_shader_parameter("depth_texture", depth_texture)
+		main.primary_screen.material_override.set_shader_parameter("depth_guide_texture", depth_viewport.get_texture())
 	if main.comp_shader_mat_left:
 		main.comp_shader_mat_left.set_shader_parameter("depth_texture", depth_texture)
+		main.comp_shader_mat_left.set_shader_parameter("upsampled_depth_texture", upsample_viewport.get_texture())
+		main.comp_shader_mat_left.set_shader_parameter("offset_texture", offset_viewport.get_texture())
 	if main.comp_shader_mat_right:
 		main.comp_shader_mat_right.set_shader_parameter("depth_texture", depth_texture)
+		main.comp_shader_mat_right.set_shader_parameter("upsampled_depth_texture", upsample_viewport.get_texture())
+		main.comp_shader_mat_right.set_shader_parameter("offset_texture", offset_viewport.get_texture())
+
+func _setup_warp_passes():
+	upsample_viewport = SubViewport.new()
+	upsample_viewport.name = "DepthUpsampleViewport"
+	upsample_viewport.disable_3d = true
+	upsample_viewport.render_target_update_mode = SubViewport.UPDATE_DISABLED
+	upsample_viewport.transparent_bg = true
+	var upsample_rect = ColorRect.new()
+	upsample_rect.color = Color.WHITE
+	upsample_rect.set_anchors_preset(Control.PRESET_FULL_RECT)
+	upsample_mat = ShaderMaterial.new()
+	upsample_mat.shader = load("res://src/shaders/depth_upsample.gdshader")
+	upsample_mat.set_shader_parameter("depth_texture", depth_texture)
+	upsample_mat.set_shader_parameter("depth_guide_texture", depth_viewport.get_texture())
+	upsample_rect.material = upsample_mat
+	upsample_viewport.add_child(upsample_rect)
+	main.add_child(upsample_viewport)
+
+	offset_viewport = SubViewport.new()
+	offset_viewport.name = "DepthOffsetViewport"
+	offset_viewport.disable_3d = true
+	offset_viewport.render_target_update_mode = SubViewport.UPDATE_DISABLED
+	offset_viewport.transparent_bg = true
+	var offset_rect = ColorRect.new()
+	offset_rect.color = Color.WHITE
+	offset_rect.set_anchors_preset(Control.PRESET_FULL_RECT)
+	offset_mat = ShaderMaterial.new()
+	offset_mat.shader = load("res://src/shaders/depth_offset.gdshader")
+	offset_mat.set_shader_parameter("upsampled_depth_texture", upsample_viewport.get_texture())
+	offset_rect.material = offset_mat
+	offset_viewport.add_child(offset_rect)
+	main.add_child(offset_viewport)
+
+	_resize_warp_passes()
+
+# Sized off native_resolution (the stream's real resolution) rather than a
+# fixed constant, so the passes track resolution changes/restarts. Cheap to
+# call every frame - it's a no-op once the size matches.
+func _resize_warp_passes():
+	# upsample_mat decodes YUV directly (see depth_upsample.gdshader) and
+	# needs the same uv_region the primary screen's own materials use, so
+	# its "hi" color sample lands on the same frame position the final
+	# gather shader will warp. Kept outside the resize early-return below
+	# since the primary screen's region can change independently of the
+	# stream's own resolution (e.g. a monitor-selection change).
+	if upsample_mat and main.primary_screen:
+		upsample_mat.set_shader_parameter("uv_region", main.primary_screen.uv_region)
+
+	var src = main.native_resolution
+	if src.x <= 0 or src.y <= 0:
+		return
+	var target = Vector2i(maxi(src.x / PASS_DIVISOR, PASS_MIN_SIZE), maxi(src.y / PASS_DIVISOR, PASS_MIN_SIZE))
+	if target == _pass_size:
+		return
+	_pass_size = target
+	upsample_viewport.size = target
+	offset_viewport.size = target
+	offset_mat.set_shader_parameter("disp_texels", _pass_parallax * float(target.x))
+	for mat in [main.comp_shader_mat_left, main.comp_shader_mat_right]:
+		if mat:
+			mat.set_shader_parameter("mode5_parallax", _pass_parallax)
 
 func bind_stream_texture():
 	if not depth_target:
@@ -54,14 +180,24 @@ func bind_stream_texture():
 	elif main.stream_viewport:
 		depth_target.texture = main.stream_viewport.get_texture()
 
-func set_enabled(val: bool):
+func set_enabled(val: bool, run_warp_passes: bool = false):
 	enabled = val
 	if depth_viewport:
 		depth_viewport.render_target_update_mode = SubViewport.UPDATE_ALWAYS if val else SubViewport.UPDATE_DISABLED
+	# Only stereo_mode 5/6 (MiDaS-GPU / MiDaS-NNAPI) consume these - leave them
+	# off for the older modes 3/4 so they stay a clean, unaffected performance
+	# baseline to compare against.
+	var run_passes = val and run_warp_passes
+	if upsample_viewport:
+		upsample_viewport.render_target_update_mode = SubViewport.UPDATE_ALWAYS if run_passes else SubViewport.UPDATE_DISABLED
+	if offset_viewport:
+		offset_viewport.render_target_update_mode = SubViewport.UPDATE_ALWAYS if run_passes else SubViewport.UPDATE_DISABLED
 
 func process(delta: float):
 	if not enabled or not main.is_streaming:
 		return
+
+	_resize_warp_passes()
 
 	if main.stream_backend.has_method("submit_depth_frame"):
 		submit_timer += delta

--- a/src/depth_estimator.gd
+++ b/src/depth_estimator.gd
@@ -26,7 +26,7 @@ var submit_interval: float = 0.05
 var model_size: int = 256
 var _poll_timer: float = 0.0
 
-# stereo_mode 5/6 (MiDaS-GPU / MiDaS-NNAPI)'s upsample+offset passes - see
+# stereo_mode 5/6 (MiDaS-GPU / MiDaS-Std)'s upsample+offset passes - see
 # depth_upsample.gdshader / depth_offset.gdshader for what these compute.
 # Run once per frame, shared by both eyes, at a quarter of the stream's own
 # resolution (matches Gilleece/moonlight-android-xr's own upsampleWidth =
@@ -35,11 +35,42 @@ var _poll_timer: float = 0.0
 # performance, since the same expensive bilateral/search work was repeated
 # per eye per full-res pixel instead of once for the whole frame.
 const PASS_DIVISOR := 4
+# stereo_mode 10 (MiDaS-Fast) only - shrinks the pre-pass's linear resolution
+# further than PASS_DIVISOR, on the same GPU-cost theory as the throttle
+# below. Selected via _pass_divisor in set_enabled(). No power-of-2
+# requirement - this only ever feeds an integer division in GDScript
+# (_resize_warp_passes(), called once per native_resolution change, not
+# per-pixel/per-frame), so any divisor costs the same at runtime; only the
+# resulting resolution (and therefore quality vs. GPU cost) changes.
+const EX_PASS_DIVISOR := 10
 const PASS_MIN_SIZE := 160
+var _pass_divisor: int = PASS_DIVISOR
 var upsample_viewport: SubViewport
 var upsample_mat: ShaderMaterial
 var offset_viewport: SubViewport
 var offset_mat: ShaderMaterial
+# stereo_mode 10 (MiDaS-Fast) only: throttles these two passes to UPDATE_ONCE
+# on this timer instead of UPDATE_ALWAYS, re-rendering the occlusion search
+# at warp_update_interval instead of every render frame (up to 90Hz), even
+# though the depth data feeding them only refreshes at submit_interval's
+# 20Hz. On-device testing (2026-08-18) found NO measurable FPS gain from
+# this on stereo_mode 6 (MiDaS-Std, which stayed on UPDATE_ALWAYS as a
+# result) - the pre-pass apparently isn't the actual bottleneck. Kept as its
+# own mode (not folded into MiDaS-Std) to keep poking at this without
+# risking the known-good mode; the per-eye per-pixel Newton-refinement
+# gather in yuv_display.gdshader (runs at full render resolution every
+# frame regardless of this throttle) is the next suspect.
+var warp_update_interval: float = 1.0 / 30.0
+var _warp_timer: float = 0.0
+var _warp_passes_active: bool = false
+var _warp_throttled: bool = false
+# stereo_mode 10 (MiDaS-Fast) only - toggled every process() tick (one real
+# render frame, see main.gd's _process()) and pushed to comp_shader_mat_
+# left/right as warp_frame_parity. yuv_display.gdshader does 1 Newton
+# refinement step on parity 0, 0 steps (raw offset-search result, no
+# refinement) on parity 1 - amortizing that cost across pairs of frames
+# instead of paying it every frame.
+var _warp_frame_parity: int = 0
 # Matches Gilleece/moonlight-android-xr's own shipped default separation
 # (0.5% of frame width). Tested bumping this to 0.02 (~3.3x) on the theory
 # that magnitude was the remaining gap for why the depth effect still felt
@@ -158,7 +189,7 @@ func _resize_warp_passes():
 	var src = main.native_resolution
 	if src.x <= 0 or src.y <= 0:
 		return
-	var target = Vector2i(maxi(src.x / PASS_DIVISOR, PASS_MIN_SIZE), maxi(src.y / PASS_DIVISOR, PASS_MIN_SIZE))
+	var target = Vector2i(maxi(src.x / _pass_divisor, PASS_MIN_SIZE), maxi(src.y / _pass_divisor, PASS_MIN_SIZE))
 	if target == _pass_size:
 		return
 	_pass_size = target
@@ -193,24 +224,49 @@ func bind_stream_texture():
 	elif main.stream_viewport:
 		depth_target_mat.set_shader_parameter("source_tex", main.stream_viewport.get_texture())
 
-func set_enabled(val: bool, run_warp_passes: bool = false):
+func set_enabled(val: bool, run_warp_passes: bool = false, throttle_warp_passes: bool = false):
 	enabled = val
 	if depth_viewport:
 		depth_viewport.render_target_update_mode = SubViewport.UPDATE_ALWAYS if val else SubViewport.UPDATE_DISABLED
-	# Only stereo_mode 5/6 (MiDaS-GPU / MiDaS-NNAPI) consume these - leave them
-	# off for the older modes 3/4 so they stay a clean, unaffected performance
-	# baseline to compare against.
-	var run_passes = val and run_warp_passes
+	# Only stereo_mode 5/6/10 (MiDaS-GPU / MiDaS-Std / MiDaS-Fast) consume
+	# these - leave them off for the older modes 3/4 so they stay a clean,
+	# unaffected performance baseline to compare against. stereo_mode 10
+	# throttles via _warp_timer in process() (UPDATE_ONCE); everything else
+	# stays UPDATE_ALWAYS - see warp_update_interval's comment above for why.
+	_warp_passes_active = val and run_warp_passes
+	_warp_throttled = val and throttle_warp_passes
+	_warp_timer = 0.0
+	# throttle_warp_passes doubles as "this is stereo_mode 10 (MiDaS-Fast)" -
+	# the two are 1:1 today (only MiDaS-Fast opts into any of these cost-
+	# cutting measures: pre-pass throttle, pre-pass resolution, AND the
+	# Newton-step frame-parity toggle below), so one flag drives all three
+	# instead of threading more params through apply_stereo() for the same
+	# condition.
+	_pass_divisor = EX_PASS_DIVISOR if throttle_warp_passes else PASS_DIVISOR
+	_warp_frame_parity = 0
+	var mode: int = (SubViewport.UPDATE_ONCE if _warp_throttled else SubViewport.UPDATE_ALWAYS) if _warp_passes_active else SubViewport.UPDATE_DISABLED
 	if upsample_viewport:
-		upsample_viewport.render_target_update_mode = SubViewport.UPDATE_ALWAYS if run_passes else SubViewport.UPDATE_DISABLED
+		upsample_viewport.render_target_update_mode = mode
 	if offset_viewport:
-		offset_viewport.render_target_update_mode = SubViewport.UPDATE_ALWAYS if run_passes else SubViewport.UPDATE_DISABLED
+		offset_viewport.render_target_update_mode = mode
 
 func process(delta: float):
 	if not enabled or not main.is_streaming:
 		return
 
 	_resize_warp_passes()
+
+	if _warp_passes_active and _warp_throttled:
+		_warp_frame_parity = 1 - _warp_frame_parity
+		if main.comp_shader_mat_left:
+			main.comp_shader_mat_left.set_shader_parameter("warp_frame_parity", _warp_frame_parity)
+		if main.comp_shader_mat_right:
+			main.comp_shader_mat_right.set_shader_parameter("warp_frame_parity", _warp_frame_parity)
+		_warp_timer += delta
+		if _warp_timer >= warp_update_interval:
+			_warp_timer = 0.0
+			upsample_viewport.render_target_update_mode = SubViewport.UPDATE_ONCE
+			offset_viewport.render_target_update_mode = SubViewport.UPDATE_ONCE
 
 	if main.stream_backend.has_method("submit_depth_frame"):
 		submit_timer += delta

--- a/src/depth_estimator.gd
+++ b/src/depth_estimator.gd
@@ -35,42 +35,65 @@ var _poll_timer: float = 0.0
 # performance, since the same expensive bilateral/search work was repeated
 # per eye per full-res pixel instead of once for the whole frame.
 const PASS_DIVISOR := 4
-# stereo_mode 10 (MiDaS-Fast) only - shrinks the pre-pass's linear resolution
-# further than PASS_DIVISOR, on the same GPU-cost theory as the throttle
-# below. Selected via _pass_divisor in set_enabled(). No power-of-2
-# requirement - this only ever feeds an integer division in GDScript
-# (_resize_warp_passes(), called once per native_resolution change, not
-# per-pixel/per-frame), so any divisor costs the same at runtime; only the
-# resulting resolution (and therefore quality vs. GPU cost) changes.
+# stereo_mode 10/11 (MiDaS-Fast / MiDaS-Fastest) only - shrinks the
+# pre-pass's linear resolution further than PASS_DIVISOR, on the same
+# GPU-cost theory as the throttle below. Selected via _pass_divisor in
+# set_enabled() based on warp_tier. No power-of-2 requirement - this only
+# ever feeds an integer division in GDScript (_resize_warp_passes(), called
+# once per native_resolution change, not per-pixel/per-frame), so any
+# divisor costs the same at runtime; only the resulting resolution (and
+# therefore quality vs. GPU cost) changes.
 const EX_PASS_DIVISOR := 10
+const FASTEST_PASS_DIVISOR := 12
 const PASS_MIN_SIZE := 160
+# MiDaS-Fastest only: an absolute ceiling on the pre-pass size, equal to
+# what MiDaS-Fast (EX_PASS_DIVISOR=10) already produces at 2560x1440 - the
+# resolution it was tuned/tested at (2560/10=256, 1440/10=144, floored up
+# to PASS_MIN_SIZE=160). FASTEST_PASS_DIVISOR alone still scales up
+# proportionally with native_resolution, so at 4K (roughly double 1440p's
+# linear dimensions) it costs ~4x more than at 1440p for the same divisor -
+# that's the actual reason 4K costs more, not something a bigger divisor
+# alone fixes. Clamping to this ceiling means going to 4K (or beyond) never
+# makes MiDaS-Fastest's pre-pass more expensive than it already is at
+# 1440p; below that, FASTEST_PASS_DIVISOR's own result is already smaller
+# than this and the ceiling is a no-op.
+const FASTEST_PASS_MAX_SIZE := Vector2i(256, 160)
 var _pass_divisor: int = PASS_DIVISOR
 var upsample_viewport: SubViewport
 var upsample_mat: ShaderMaterial
 var offset_viewport: SubViewport
 var offset_mat: ShaderMaterial
-# stereo_mode 10 (MiDaS-Fast) only: throttles these two passes to UPDATE_ONCE
-# on this timer instead of UPDATE_ALWAYS, re-rendering the occlusion search
-# at warp_update_interval instead of every render frame (up to 90Hz), even
+# stereo_mode 10/11 only: throttles these two passes to UPDATE_ONCE on this
+# timer instead of UPDATE_ALWAYS, re-rendering the occlusion search at
+# warp_update_interval instead of every render frame (up to 90Hz), even
 # though the depth data feeding them only refreshes at submit_interval's
 # 20Hz. On-device testing (2026-08-18) found NO measurable FPS gain from
 # this on stereo_mode 6 (MiDaS-Std, which stayed on UPDATE_ALWAYS as a
-# result) - the pre-pass apparently isn't the actual bottleneck. Kept as its
-# own mode (not folded into MiDaS-Std) to keep poking at this without
-# risking the known-good mode; the per-eye per-pixel Newton-refinement
-# gather in yuv_display.gdshader (runs at full render resolution every
-# frame regardless of this throttle) is the next suspect.
+# result) - the pre-pass apparently isn't the actual bottleneck. Kept in
+# these separate modes (not folded into MiDaS-Std) to keep poking at this
+# without risking the known-good mode; the per-eye per-pixel Newton-
+# refinement gather in yuv_display.gdshader (runs at full render resolution
+# every frame regardless of this throttle) is the next suspect.
 var warp_update_interval: float = 1.0 / 30.0
 var _warp_timer: float = 0.0
 var _warp_passes_active: bool = false
 var _warp_throttled: bool = false
-# stereo_mode 10 (MiDaS-Fast) only - toggled every process() tick (one real
-# render frame, see main.gd's _process()) and pushed to comp_shader_mat_
-# left/right as warp_frame_parity. yuv_display.gdshader does 1 Newton
-# refinement step on parity 0, 0 steps (raw offset-search result, no
-# refinement) on parity 1 - amortizing that cost across pairs of frames
-# instead of paying it every frame.
-var _warp_frame_parity: int = 0
+# 0 = MiDaS-Std (no throttling/shrinking - full quality, unthrottled), 1 =
+# MiDaS-Fast, 2 = MiDaS-Fastest. Set via set_enabled()'s warp_tier param;
+# drives _pass_divisor and WARP_NEWTON_PERIOD below.
+var _warp_tier: int = 0
+# stereo_mode 10/11 only - a 1-indexed counter, incremented every process()
+# tick (one real render frame, see main.gd's _process()) while a throttled
+# tier is active. Pushed to comp_shader_mat_left/right as warp_newton_steps
+# (1 on the tick where counter % WARP_NEWTON_PERIOD[_warp_tier] == 0, else
+# 0) - yuv_display.gdshader just reads that uniform directly rather than
+# special-casing stereo_mode itself, so adding another tier only needs an
+# entry here, not a shader change. MiDaS-Fast (tier 1) does 1 Newton step
+# every 2nd frame (alternating); MiDaS-Fastest (tier 2) does 1 every 3rd
+# frame, 0 the other two - both amortize that per-pixel refinement cost
+# across frames instead of paying it every frame.
+const WARP_NEWTON_PERIOD: Array[int] = [1, 2, 3]
+var _warp_frame_counter: int = 0
 # Matches Gilleece/moonlight-android-xr's own shipped default separation
 # (0.5% of frame width). Tested bumping this to 0.02 (~3.3x) on the theory
 # that magnitude was the remaining gap for why the depth effect still felt
@@ -190,6 +213,8 @@ func _resize_warp_passes():
 	if src.x <= 0 or src.y <= 0:
 		return
 	var target = Vector2i(maxi(src.x / _pass_divisor, PASS_MIN_SIZE), maxi(src.y / _pass_divisor, PASS_MIN_SIZE))
+	if _warp_tier == 2:
+		target = Vector2i(mini(target.x, FASTEST_PASS_MAX_SIZE.x), mini(target.y, FASTEST_PASS_MAX_SIZE.y))
 	if target == _pass_size:
 		return
 	_pass_size = target
@@ -224,31 +249,45 @@ func bind_stream_texture():
 	elif main.stream_viewport:
 		depth_target_mat.set_shader_parameter("source_tex", main.stream_viewport.get_texture())
 
-func set_enabled(val: bool, run_warp_passes: bool = false, throttle_warp_passes: bool = false):
+func set_enabled(val: bool, run_warp_passes: bool = false, warp_tier: int = 0):
 	enabled = val
 	if depth_viewport:
+		# Tried throttling this to UPDATE_ONCE at submit_interval's 20Hz
+		# instead of UPDATE_ALWAYS (2026-08-18) on the theory that
+		# re-rendering the downscale every render frame for 20Hz-consumed
+		# data was wasted GPU work - on-device testing found NO measurable
+		# FPS gain, just the throttle's own added pipeline latency, so
+		# reverted. Unlike the warp passes, this pass apparently isn't worth
+		# throttling - it's a single cheap fullscreen blit, not the
+		# occlusion-search work those passes do.
 		depth_viewport.render_target_update_mode = SubViewport.UPDATE_ALWAYS if val else SubViewport.UPDATE_DISABLED
-	# Only stereo_mode 5/6/10 (MiDaS-GPU / MiDaS-Std / MiDaS-Fast) consume
-	# these - leave them off for the older modes 3/4 so they stay a clean,
-	# unaffected performance baseline to compare against. stereo_mode 10
-	# throttles via _warp_timer in process() (UPDATE_ONCE); everything else
-	# stays UPDATE_ALWAYS - see warp_update_interval's comment above for why.
+	# Only stereo_mode 5/6/10/11 (MiDaS-GPU / MiDaS-Std / MiDaS-Fast /
+	# MiDaS-Fastest) consume these - leave them off for the older modes 3/4
+	# so they stay a clean, unaffected performance baseline to compare
+	# against. Tiers 1/2 throttle via _warp_timer in process() (UPDATE_ONCE);
+	# tier 0 (MiDaS-Std) stays UPDATE_ALWAYS - see warp_update_interval's
+	# comment above for why.
 	_warp_passes_active = val and run_warp_passes
-	_warp_throttled = val and throttle_warp_passes
+	_warp_tier = warp_tier if _warp_passes_active else 0
+	_warp_throttled = _warp_tier > 0
 	_warp_timer = 0.0
-	# throttle_warp_passes doubles as "this is stereo_mode 10 (MiDaS-Fast)" -
-	# the two are 1:1 today (only MiDaS-Fast opts into any of these cost-
-	# cutting measures: pre-pass throttle, pre-pass resolution, AND the
-	# Newton-step frame-parity toggle below), so one flag drives all three
-	# instead of threading more params through apply_stereo() for the same
-	# condition.
-	_pass_divisor = EX_PASS_DIVISOR if throttle_warp_passes else PASS_DIVISOR
-	_warp_frame_parity = 0
+	_warp_frame_counter = 0
+	match _warp_tier:
+		1: _pass_divisor = EX_PASS_DIVISOR
+		2: _pass_divisor = FASTEST_PASS_DIVISOR
+		_: _pass_divisor = PASS_DIVISOR
+	_push_warp_newton_steps(2 if _warp_tier == 0 else 0)
 	var mode: int = (SubViewport.UPDATE_ONCE if _warp_throttled else SubViewport.UPDATE_ALWAYS) if _warp_passes_active else SubViewport.UPDATE_DISABLED
 	if upsample_viewport:
 		upsample_viewport.render_target_update_mode = mode
 	if offset_viewport:
 		offset_viewport.render_target_update_mode = mode
+
+func _push_warp_newton_steps(steps: int):
+	if main.comp_shader_mat_left:
+		main.comp_shader_mat_left.set_shader_parameter("warp_newton_steps", steps)
+	if main.comp_shader_mat_right:
+		main.comp_shader_mat_right.set_shader_parameter("warp_newton_steps", steps)
 
 func process(delta: float):
 	if not enabled or not main.is_streaming:
@@ -257,11 +296,9 @@ func process(delta: float):
 	_resize_warp_passes()
 
 	if _warp_passes_active and _warp_throttled:
-		_warp_frame_parity = 1 - _warp_frame_parity
-		if main.comp_shader_mat_left:
-			main.comp_shader_mat_left.set_shader_parameter("warp_frame_parity", _warp_frame_parity)
-		if main.comp_shader_mat_right:
-			main.comp_shader_mat_right.set_shader_parameter("warp_frame_parity", _warp_frame_parity)
+		_warp_frame_counter += 1
+		var period: int = WARP_NEWTON_PERIOD[_warp_tier]
+		_push_warp_newton_steps(1 if (_warp_frame_counter % period == 0) else 0)
 		_warp_timer += delta
 		if _warp_timer >= warp_update_interval:
 			_warp_timer = 0.0

--- a/src/depth_estimator.gd
+++ b/src/depth_estimator.gd
@@ -3,7 +3,8 @@ extends RefCounted
 
 var main: Node3D
 var depth_viewport: SubViewport
-var depth_target: TextureRect
+var depth_target: ColorRect
+var depth_target_mat: ShaderMaterial
 var depth_texture: ImageTexture
 var enabled: bool = false
 var submit_timer: float = 0.0
@@ -69,28 +70,22 @@ func setup():
 	depth_viewport.render_target_update_mode = SubViewport.UPDATE_DISABLED
 	depth_viewport.transparent_bg = true
 
-	depth_target = TextureRect.new()
+	# A plain shader-sampled ColorRect, NOT a TextureRect+STRETCH_SCALE (see
+	# depth_downscale.gdshader for why that was replaced - it showed a
+	# persistent crop to a sub-region of the frame, most likely a stale
+	# cached source-size in TextureRect's stretch math not tracking
+	# comp_viewport's live resizes). UV 0..1 always covers the FULL current
+	# source texture with plain texture() sampling - depth_texture is
+	# assumed to cover frame UV 0..1 1:1 everywhere else in the pipeline
+	# (the warp shaders index into it via tile_uv directly), matching
+	# Gilleece/moonlight-android-xr's own downscale (DOWNSCALE_FRAGMENT_SRC):
+	# a plain UV stretch with no aspect correction at all.
+	depth_target = ColorRect.new()
 	depth_target.name = "DepthTarget"
-	depth_target.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
-	# Plain stretch-to-fill, NOT aspect-preserved: depth_texture is assumed
-	# to cover frame UV 0..1 1:1 everywhere else in the pipeline (the warp
-	# shaders index into it via tile_uv directly) - KEEP_ASPECT_CENTERED
-	# would letterbox a 16:9-ish stream into this square target, wasting a
-	# fifth of the model's input on empty margin AND silently breaking that
-	# 1:1 UV assumption for the entire frame, not just the edges.
-	# Gilleece/moonlight-android-xr's own downscale (DOWNSCALE_FRAGMENT_SRC)
-	# confirms this: a plain UV stretch with no aspect correction at all.
-	depth_target.stretch_mode = TextureRect.STRETCH_SCALE
-	depth_target.size = Vector2i(model_size, model_size)
 	depth_target.set_anchors_preset(Control.PRESET_FULL_RECT)
-	# The default filter is a single bilinear tap - for a ~10x reduction
-	# (e.g. 2560px stream -> model_size), that aliases badly, feeding MiDaS a
-	# noisier input than it needs. Gilleece/moonlight-android-xr does an
-	# explicit 4x4 box filter in a shader for exactly this
-	# (DOWNSCALE_FRAGMENT_SRC); mipmap filtering is Godot's built-in
-	# equivalent - the GPU picks/blends the right pre-averaged mip level
-	# instead of a single raw sample.
-	depth_target.texture_filter = CanvasItem.TEXTURE_FILTER_LINEAR_WITH_MIPMAPS
+	depth_target_mat = ShaderMaterial.new()
+	depth_target_mat.shader = load("res://src/shaders/depth_downscale.gdshader")
+	depth_target.material = depth_target_mat
 	depth_viewport.add_child(depth_target)
 	main.add_child(depth_viewport)
 
@@ -106,10 +101,12 @@ func setup():
 		main.comp_shader_mat_left.set_shader_parameter("depth_texture", depth_texture)
 		main.comp_shader_mat_left.set_shader_parameter("upsampled_depth_texture", upsample_viewport.get_texture())
 		main.comp_shader_mat_left.set_shader_parameter("offset_texture", offset_viewport.get_texture())
+		main.comp_shader_mat_left.set_shader_parameter("depth_guide_texture", depth_viewport.get_texture())
 	if main.comp_shader_mat_right:
 		main.comp_shader_mat_right.set_shader_parameter("depth_texture", depth_texture)
 		main.comp_shader_mat_right.set_shader_parameter("upsampled_depth_texture", upsample_viewport.get_texture())
 		main.comp_shader_mat_right.set_shader_parameter("offset_texture", offset_viewport.get_texture())
+		main.comp_shader_mat_right.set_shader_parameter("depth_guide_texture", depth_viewport.get_texture())
 
 func _setup_warp_passes():
 	upsample_viewport = SubViewport.new()
@@ -175,10 +172,26 @@ func _resize_warp_passes():
 func bind_stream_texture():
 	if not depth_target:
 		return
+	# comp.in_use (switch_to_stereo_comp_layer() active) EXPLICITLY sets
+	# primary_screen.comp_viewport (the mono viewport) to UPDATE_DISABLED in
+	# favor of comp_viewport_left/right - depth capture used to silently
+	# freeze on whatever the mono viewport last rendered before switching to
+	# stereo (often mid-welcome-screen), feeding MiDaS a single stale frame
+	# forever instead of live video (fixed by forcing it back to
+	# UPDATE_ALWAYS in settings_controller.gd's apply_stereo() whenever
+	# depth is enabled). comp_viewport_left is NOT a valid depth-capture
+	# source: it's rendered by comp_shader_mat_left, the SAME material
+	# whose stereo_mode we set to 7/8/9 for the DMap debug views - sourcing
+	# depth capture from it would mean depth_guide_texture circularly
+	# depends on its own output (DMap modes) or MiDaS sees the
+	# already-warped stereo image instead of plain video (warp modes 5/6,
+	# compounding distortion frame over frame). The mono comp_viewport
+	# (comp_shader_mat, permanently stereo_mode=0) is the only semantically
+	# correct source.
 	if main.comp.in_use and main.primary_screen and main.primary_screen.comp_viewport:
-		depth_target.texture = main.primary_screen.comp_viewport.get_texture()
+		depth_target_mat.set_shader_parameter("source_tex", main.primary_screen.comp_viewport.get_texture())
 	elif main.stream_viewport:
-		depth_target.texture = main.stream_viewport.get_texture()
+		depth_target_mat.set_shader_parameter("source_tex", main.stream_viewport.get_texture())
 
 func set_enabled(val: bool, run_warp_passes: bool = false):
 	enabled = val

--- a/src/depth_estimator.gd
+++ b/src/depth_estimator.gd
@@ -25,17 +25,6 @@ var submit_timer: float = 0.0
 var submit_interval: float = 0.05
 var model_size: int = 256
 var _poll_timer: float = 0.0
-# Temporary (2026-08-18): confirms the depth pipeline is actually live -
-# capturing, submitting, and getting real (non-degenerate) depth data back -
-# while investigating why MiDaS-Fastest looks worse than Fast/Std even
-# though it's confirmed NOT a resolution difference. Logs once/sec via
-# main._log() (tag [DEPTH]), not every submit_interval tick, to stay
-# readable in logcat. Remove once the Fastest investigation is done.
-var _debug_log_timer: float = 0.0
-var _debug_last_submit_bytes: int = -1
-var _debug_last_poll_bytes: int = -1
-var _debug_last_poll_min: int = -1
-var _debug_last_poll_max: int = -1
 
 # stereo_mode 5/6 (MiDaS-GPU / MiDaS-Std)'s upsample+offset passes - see
 # depth_upsample.gdshader / depth_offset.gdshader for what these compute.
@@ -288,7 +277,6 @@ func set_enabled(val: bool, run_warp_passes: bool = false, warp_tier: int = 0):
 		2: _pass_divisor = FASTEST_PASS_DIVISOR
 		_: _pass_divisor = PASS_DIVISOR
 	_push_warp_newton_steps(2 if _warp_tier == 0 else 0)
-	main._log("[DEPTH] set_enabled val=%s run_warp_passes=%s warp_tier=%d pass_divisor=%d native_res=%s" % [str(val), str(run_warp_passes), _warp_tier, _pass_divisor, str(main.native_resolution)])
 	var mode: int = (SubViewport.UPDATE_ONCE if _warp_throttled else SubViewport.UPDATE_ALWAYS) if _warp_passes_active else SubViewport.UPDATE_DISABLED
 	if upsample_viewport:
 		upsample_viewport.render_target_update_mode = mode
@@ -324,11 +312,8 @@ func process(delta: float):
 			var img = depth_viewport.get_texture().get_image()
 			if img != null and not img.is_empty():
 				var data = img.get_data()
-				_debug_last_submit_bytes = data.size()
 				if data.size() > 0:
 					main.stream_backend.submit_depth_frame(data, model_size, model_size)
-			else:
-				_debug_last_submit_bytes = 0
 
 	if main.stream_backend.has_method("get_depth_map"):
 		_poll_timer += delta
@@ -338,23 +323,3 @@ func process(delta: float):
 			if depth_bytes != null and depth_bytes.size() == model_size * model_size:
 				var depth_image = Image.create_from_data(model_size, model_size, false, Image.FORMAT_L8, depth_bytes)
 				depth_texture.update(depth_image)
-				_debug_last_poll_bytes = depth_bytes.size()
-				var lo = 255
-				var hi = 0
-				for i in range(0, depth_bytes.size(), 17):
-					var v = depth_bytes[i]
-					if v < lo: lo = v
-					if v > hi: hi = v
-				_debug_last_poll_min = lo
-				_debug_last_poll_max = hi
-			else:
-				_debug_last_poll_bytes = depth_bytes.size() if depth_bytes != null else -1
-
-	# Temporary - see _debug_log_timer's comment above.
-	_debug_log_timer += delta
-	if _debug_log_timer >= 1.0:
-		_debug_log_timer = 0.0
-		var uv_region = upsample_mat.get_shader_parameter("uv_region") if upsample_mat else null
-		main._log("[DEPTH] tier=%d pass_size=%s submit_bytes=%d poll_bytes=%d poll_range=[%d,%d] uv_region=%s" % [
-			_warp_tier, str(_pass_size), _debug_last_submit_bytes, _debug_last_poll_bytes,
-			_debug_last_poll_min, _debug_last_poll_max, str(uv_region)])

--- a/src/screen_layout.gd
+++ b/src/screen_layout.gd
@@ -6,6 +6,14 @@ class MonitorSpec:
 	var id: StringName = &""
 	var label: String = ""
 	var enabled: bool = true
+	# True when the host output has an active CRTC and could be captured at all (mirrors the
+	# host's monitor_manifest_entry_t::capturable). Distinct from `enabled`, which also folds in
+	# whether this session's outputs= currently selects it. A connected-but-disabled host output
+	# is capturable=false regardless of selection state - callers picking N monitors to request
+	# (settings_controller.gd's _real_monitor_count()/_build_staged_layout()) must filter on this,
+	# not just enabled/hint.virtual, or they can pick a monitor the host will always refuse.
+	# Defaults true for older hosts that don't send this field yet.
+	var capturable: bool = true
 	var is_primary: bool = false
 	var frame_rect: Rect2i = Rect2i()
 	var desktop_rect: Rect2i = Rect2i()
@@ -16,6 +24,7 @@ class MonitorSpec:
 			"id": String(id),
 			"label": label,
 			"enabled": enabled,
+			"capturable": capturable,
 			"is_primary": is_primary,
 			"frame_rect": [frame_rect.position.x, frame_rect.position.y, frame_rect.size.x, frame_rect.size.y],
 			"desktop_rect": [desktop_rect.position.x, desktop_rect.position.y, desktop_rect.size.x, desktop_rect.size.y],
@@ -27,6 +36,7 @@ class MonitorSpec:
 		m.id = StringName(d.get("id", ""))
 		m.label = d.get("label", "")
 		m.enabled = d.get("enabled", true)
+		m.capturable = d.get("capturable", true)
 		m.is_primary = d.get("is_primary", false)
 		var fr: Array = d.get("frame_rect", [0, 0, 0, 0])
 		m.frame_rect = Rect2i(fr[0], fr[1], fr[2], fr[3])

--- a/src/settings_controller.gd
+++ b/src/settings_controller.gd
@@ -6,7 +6,13 @@ var _restart_pending: bool = false
 var _restart_seq: int = 0
 
 var sbs_labels: Array = ["Off", "Stretch", "Crop"]
-var ai_3d_labels: Array = ["2D", "MiDaS", "MiDaS-GPU", "MiDaS-NNAPI", "MiDaS-DMap", "MiDaS-DMap-Raw", "MiDaS-DMap-Input"]
+# MiDaS-GPU is disabled here (not deleted) - the "stale depth_texture from a
+# successful GPU run" theory was ruled out too (segment-by-segment log
+# analysis 2026-08-18 showed MiDaS/MiDaS-NNAPI at 0% success both before AND
+# immediately after MiDaS-GPU ran) but keeping the model/code around for
+# later re-testing was still explicitly requested - see get_stereo_mode()'s
+# commented-out mapping below to re-enable.
+var ai_3d_labels: Array = ["2D", "MiDaS", "MiDaS-NNAPI", "MiDaS-DMap", "MiDaS-DMap-Raw", "MiDaS-DMap-Input"]
 var idle_labels: Array = ["Off", "5m", "15m", "30m", "60m"]
 var idle_values: Array = [0, 5, 15, 30, 60]
 
@@ -21,15 +27,14 @@ func get_stereo_mode() -> int:
 	elif main.ai_3d_mode == 1:
 		return 3
 	elif main.ai_3d_mode == 2:
-		return 5
-	elif main.ai_3d_mode == 3:
 		return 6
-	elif main.ai_3d_mode == 4:
+	elif main.ai_3d_mode == 3:
 		return 7 # MiDaS-DMap
-	elif main.ai_3d_mode == 5:
+	elif main.ai_3d_mode == 4:
 		return 8 # MiDaS-DMap-Raw
-	elif main.ai_3d_mode == 6:
+	elif main.ai_3d_mode == 5:
 		return 9 # MiDaS-DMap-Input
+	# elif main.ai_3d_mode == X: return 5  # MiDaS-GPU (disabled, not deleted)
 	else:
 		return 4
 
@@ -51,7 +56,7 @@ func cycle_ai_3d_mode():
 		return
 	if main.sbs_mode > 0:
 		return
-	main.ai_3d_mode = (main.ai_3d_mode + 1) % 7
+	main.ai_3d_mode = (main.ai_3d_mode + 1) % 6
 	_save_setting(main._ui_3d_btn, ai_3d_labels[main.ai_3d_mode])
 	apply_stereo()
 

--- a/src/settings_controller.gd
+++ b/src/settings_controller.gd
@@ -6,7 +6,7 @@ var _restart_pending: bool = false
 var _restart_seq: int = 0
 
 var sbs_labels: Array = ["Off", "Stretch", "Crop"]
-var ai_3d_labels: Array = ["2D", "MiDaS"]
+var ai_3d_labels: Array = ["2D", "MiDaS", "MiDaS-GPU", "MiDaS-NNAPI", "MiDaS-DMap"]
 var idle_labels: Array = ["Off", "5m", "15m", "30m", "60m"]
 var idle_values: Array = [0, 5, 15, 30, 60]
 
@@ -20,6 +20,12 @@ func get_stereo_mode() -> int:
 		return 0
 	elif main.ai_3d_mode == 1:
 		return 3
+	elif main.ai_3d_mode == 2:
+		return 5
+	elif main.ai_3d_mode == 3:
+		return 6
+	elif main.ai_3d_mode == 4:
+		return 7
 	else:
 		return 4
 
@@ -41,7 +47,7 @@ func cycle_ai_3d_mode():
 		return
 	if main.sbs_mode > 0:
 		return
-	main.ai_3d_mode = (main.ai_3d_mode + 1) % 2
+	main.ai_3d_mode = (main.ai_3d_mode + 1) % 5
 	_save_setting(main._ui_3d_btn, ai_3d_labels[main.ai_3d_mode])
 	apply_stereo()
 
@@ -60,13 +66,25 @@ func apply_stereo():
 	if main.screen_mesh.material_override is ShaderMaterial:
 		main.screen_mesh.material_override.set_shader_parameter("stereo_mode", mode)
 	if main.depth_estimator:
-		main.depth_estimator.set_enabled(mode >= 3)
+		# mode 7 (MiDaS-DMap) now visualizes upsampled_depth_texture (the real
+		# post-upsample data the actual warp uses), not the raw pre-upsample
+		# depth_texture, so it needs the warp passes running too.
+		main.depth_estimator.set_enabled(mode >= 3, mode == 5 or mode == 6 or mode == 7)
 		if mode >= 3 and main.depth_estimator.depth_texture:
+			var de = main.depth_estimator
+			var upsampled_tex = de.upsample_viewport.get_texture() if de.upsample_viewport else null
+			var offset_tex = de.offset_viewport.get_texture() if de.offset_viewport else null
 			if main.comp_shader_mat_left:
-				main.comp_shader_mat_left.set_shader_parameter("depth_texture", main.depth_estimator.depth_texture)
+				main.comp_shader_mat_left.set_shader_parameter("depth_texture", de.depth_texture)
+				main.comp_shader_mat_left.set_shader_parameter("upsampled_depth_texture", upsampled_tex)
+				main.comp_shader_mat_left.set_shader_parameter("offset_texture", offset_tex)
 			if main.comp_shader_mat_right:
-				main.comp_shader_mat_right.set_shader_parameter("depth_texture", main.depth_estimator.depth_texture)
-	main.stream_backend.set_depth_model(1 if mode == 4 else 0)
+				main.comp_shader_mat_right.set_shader_parameter("depth_texture", de.depth_texture)
+				main.comp_shader_mat_right.set_shader_parameter("upsampled_depth_texture", upsampled_tex)
+				main.comp_shader_mat_right.set_shader_parameter("offset_texture", offset_tex)
+	# mode 7 (MiDaS-DMap) reuses the MiDaS-NNAPI model/inference (index 3) - it's
+	# a pure visualization of that same depth data, not a separate source.
+	main.stream_backend.set_depth_model(1 if mode == 4 else (2 if mode == 5 else (3 if mode == 6 or mode == 7 else 0)))
 
 func toggle_passthrough():
 	if not main.is_xr_active or not main.passthrough_supported:
@@ -476,7 +494,7 @@ func apply_screen_layout(new_layout: ScreenLayout):
 func _real_monitor_count() -> int:
 	var count = 0
 	for m in main.layout.monitors:
-		if not m.hint.get("virtual", false):
+		if not m.hint.get("virtual", false) and m.capturable:
 			count += 1
 	return count
 
@@ -531,7 +549,11 @@ func select_monitor_preset(id: StringName):
 func _build_staged_layout() -> ScreenLayout:
 	var real_monitors: Array = []
 	for m in main.layout.monitors:
-		if not m.hint.get("virtual", false):
+		# Excludes capturable=false (connected-but-disabled host outputs) too, not just
+		# virtual placeholders - otherwise the N-leftmost-by-x pick below can select a
+		# monitor the host will always refuse, silently wasting a slot (the host drops it
+		# from capture but this client still thinks it asked for N real monitors).
+		if not m.hint.get("virtual", false) and m.capturable:
 			real_monitors.append(m)
 	main._log("[LAYOUT] _build_staged_layout: main.layout.monitors=%d real=%d staged_physical=%d staged_virtual=%d source=%s" % [main.layout.monitors.size(), real_monitors.size(), main._staged_physical_count, main._staged_virtual_count, str(main.layout.source)])
 	if real_monitors.is_empty():
@@ -654,6 +676,20 @@ func _apply_preset_positions_to_screens():
 				var fr: Array = data.get("free_rot", [s.rotation.x, s.rotation.y, s.rotation.z])
 				s.position = Vector3(fp[0], fp[1], fp[2])
 				s.rotation = Vector3(fr[0], fr[1], fr[2])
+	# Primary itself is deliberately never repositioned above (it's the free-
+	# mode anchor everything else is placed relative to) - but Godot's
+	# CollisionObject3D only pushes a node's transform to PhysicsServer3D on
+	# NOTIFICATION_TRANSFORM_CHANGED, which a node that never actually moves
+	# never receives. Confirmed live: right after adding a second monitor,
+	# primary's own pointer/raycast interaction went laggy/unusable (its
+	# Area3D's physics-side transform was stale relative to whatever the new
+	# secondary's Area3D just did to the broadphase) until manually grabbing
+	# and moving primary even slightly, which fixed it - because a real grab
+	# always writes global_position, firing the notification this never
+	# otherwise gets. Reassigning to its own current transform is a no-op
+	# geometrically but still fires that notification, without needing an
+	# actual (visible) move.
+	primary.global_transform = primary.global_transform
 	if main.comp.available:
 		main.comp.update_cylinder_params()
 

--- a/src/settings_controller.gd
+++ b/src/settings_controller.gd
@@ -12,7 +12,25 @@ var sbs_labels: Array = ["Off", "Stretch", "Crop"]
 # parameters on the w8a8 model, see git history 2026-08-18) is fixed now,
 # so GPU isn't needed as a working comparison point anymore. Don't restore
 # a mapping for stereo_mode 5 without re-adding that code.
-var ai_3d_labels: Array = ["2D", "MiDaS", "MiDaS-NNAPI", "MiDaS-DMap", "MiDaS-DMap-Raw", "MiDaS-DMap-Input"]
+# The original "MiDaS" mode (a single-sample parallax shift, stereo_mode 3)
+# is REMOVED too (2026-08-18) - once MiDaS-Fast (below) reached similar
+# quality at similar performance on-device, there was no reason to keep the
+# cruder mode around. stereo_mode 3/4's shader branch in yuv_display.gdshader
+# is dead code left in place (harmless, costs nothing unless selected) rather
+# than deleted - see stereo_mode 4/5's own history for the same pattern.
+# MiDaS-Fast (stereo_mode 10) is the same occlusion-aware warp as MiDaS-Std
+# (stereo_mode 6, same model/inference), but with its upsample/offset warp
+# passes throttled + shrunk (EX_PASS_DIVISOR) and the per-eye Newton
+# refinement in yuv_display.gdshader amortized to every other frame - see
+# warp_update_interval's comment in depth_estimator.gd for the full
+# GPU-cost investigation this came out of. Confirmed on-device (2026-08-18)
+# to land near MiDaS-Std's quality at close to the old crude mode's
+# framerate. Kept as its own mode (not folded into MiDaS-Std) so MiDaS-Std
+# stays the unthrottled/known-good reference to compare against.
+# MiDaS-Fast comes before MiDaS-Std in the cycle order (not alphabetical/
+# quality order) so a first-time user cycling through options lands on the
+# faster mode first, rather than possibly judging performance off MiDaS-Std.
+var ai_3d_labels: Array = ["2D", "MiDaS-Fast", "MiDaS-Std", "MiDaS-DMap", "MiDaS-DMap-Raw", "MiDaS-DMap-Input"]
 var idle_labels: Array = ["Off", "5m", "15m", "30m", "60m"]
 var idle_values: Array = [0, 5, 15, 30, 60]
 
@@ -25,9 +43,9 @@ func get_stereo_mode() -> int:
 	if main.ai_3d_mode == 0:
 		return 0
 	elif main.ai_3d_mode == 1:
-		return 3
+		return 10 # MiDaS-Fast (throttled/shrunk warp passes)
 	elif main.ai_3d_mode == 2:
-		return 6
+		return 6 # MiDaS-Std
 	elif main.ai_3d_mode == 3:
 		return 7 # MiDaS-DMap
 	elif main.ai_3d_mode == 4:
@@ -84,8 +102,10 @@ func apply_stereo():
 		# passes running too. mode 8 (MiDaS-DMap-Raw) visualizes the raw
 		# pre-upsample depth_texture directly - no warp passes needed. mode 9
 		# (MiDaS-DMap-Input) visualizes the literal color capture fed to the
-		# model - also no warp passes needed.
-		main.depth_estimator.set_enabled(mode >= 3, mode == 5 or mode == 6 or mode == 7)
+		# model - also no warp passes needed. mode 10 (MiDaS-Fast) is the same
+		# warp passes as mode 6, just throttled - see warp_update_interval's
+		# comment in depth_estimator.gd.
+		main.depth_estimator.set_enabled(mode >= 3, mode == 5 or mode == 6 or mode == 7 or mode == 10, mode == 10)
 		# switch_to_stereo_comp_layer() (called just above) unconditionally sets
 		# primary_screen.comp_viewport (the mono viewport, comp_shader_mat's
 		# always-stereo_mode=0 output) to UPDATE_DISABLED in favor of
@@ -114,16 +134,17 @@ func apply_stereo():
 				main.comp_shader_mat_right.set_shader_parameter("upsampled_depth_texture", upsampled_tex)
 				main.comp_shader_mat_right.set_shader_parameter("offset_texture", offset_tex)
 				main.comp_shader_mat_right.set_shader_parameter("depth_guide_texture", guide_tex)
-	# modes 7/8/9 (MiDaS-DMap, MiDaS-DMap-Raw, MiDaS-DMap-Input) all reuse the
-	# MiDaS-NNAPI model/inference (index 3) - they're pure visualizations of
-	# that same depth data at different pipeline stages, not a separate
-	# source. mode 9 doesn't even read the model's output (just the color
-	# capture), but MUST still stay on model index 3 here - leaving it out of
-	# this set previously silently swapped the active model down to the slow
-	# CPU/dilate-blur path (index 0) every time mode 9 was selected, which
-	# then poisoned modes 6/7/8 with stale/wrong-quality data the next time
-	# they ran, since all modes share one depth_texture/ImageTexture.
-	main.stream_backend.set_depth_model(1 if mode == 4 else (3 if mode == 6 or mode == 7 or mode == 8 or mode == 9 else 0))
+	# modes 6/7/8/9/10 (MiDaS-Std, MiDaS-DMap, MiDaS-DMap-Raw, MiDaS-DMap-
+	# Input, MiDaS-Fast) all reuse the same MiDaS-Std model/inference (index
+	# 3) - they're pure visualizations/warp-pass variants of that same depth
+	# data, not a separate source. mode 9 doesn't even read the model's
+	# output (just the color capture), but MUST still stay on model index 3
+	# here - leaving it out of this set previously silently swapped the
+	# active model down to the slow CPU/dilate-blur path (index 0) every
+	# time mode 9 was selected, which then poisoned the other modes with
+	# stale/wrong-quality data the next time they ran, since all modes share
+	# one depth_texture/ImageTexture.
+	main.stream_backend.set_depth_model(1 if mode == 4 else (3 if mode == 6 or mode == 7 or mode == 8 or mode == 9 or mode == 10 else 0))
 
 func toggle_passthrough():
 	if not main.is_xr_active or not main.passthrough_supported:

--- a/src/settings_controller.gd
+++ b/src/settings_controller.gd
@@ -6,12 +6,12 @@ var _restart_pending: bool = false
 var _restart_seq: int = 0
 
 var sbs_labels: Array = ["Off", "Stretch", "Crop"]
-# MiDaS-GPU is disabled here (not deleted) - the "stale depth_texture from a
-# successful GPU run" theory was ruled out too (segment-by-segment log
-# analysis 2026-08-18 showed MiDaS/MiDaS-NNAPI at 0% success both before AND
-# immediately after MiDaS-GPU ran) but keeping the model/code around for
-# later re-testing was still explicitly requested - see get_stereo_mode()'s
-# commented-out mapping below to re-enable.
+# MiDaS-GPU (stereo_mode 5) is REMOVED, not disabled - its underlying
+# fp16 model/weights, gradle deps, and Java code are gone
+# (DepthEstimator.java, build.sh). The real bug (wrong quantization
+# parameters on the w8a8 model, see git history 2026-08-18) is fixed now,
+# so GPU isn't needed as a working comparison point anymore. Don't restore
+# a mapping for stereo_mode 5 without re-adding that code.
 var ai_3d_labels: Array = ["2D", "MiDaS", "MiDaS-NNAPI", "MiDaS-DMap", "MiDaS-DMap-Raw", "MiDaS-DMap-Input"]
 var idle_labels: Array = ["Off", "5m", "15m", "30m", "60m"]
 var idle_values: Array = [0, 5, 15, 30, 60]
@@ -34,7 +34,6 @@ func get_stereo_mode() -> int:
 		return 8 # MiDaS-DMap-Raw
 	elif main.ai_3d_mode == 5:
 		return 9 # MiDaS-DMap-Input
-	# elif main.ai_3d_mode == X: return 5  # MiDaS-GPU (disabled, not deleted)
 	else:
 		return 4
 
@@ -56,7 +55,12 @@ func cycle_ai_3d_mode():
 		return
 	if main.sbs_mode > 0:
 		return
-	main.ai_3d_mode = (main.ai_3d_mode + 1) % 6
+	# Debug views (MiDaS-DMap/-Raw/-Input, ai_3d_mode 3-5) are disabled from
+	# cycling, not removed - their code/shader params are still wired up in
+	# get_stereo_mode()/apply_stereo() below so they can be re-enabled by
+	# bumping this modulo back to 6 whenever we're doing more work on the
+	# AI-3D pipeline and need to inspect the depth map again.
+	main.ai_3d_mode = (main.ai_3d_mode + 1) % 3
 	_save_setting(main._ui_3d_btn, ai_3d_labels[main.ai_3d_mode])
 	apply_stereo()
 
@@ -119,7 +123,7 @@ func apply_stereo():
 	# CPU/dilate-blur path (index 0) every time mode 9 was selected, which
 	# then poisoned modes 6/7/8 with stale/wrong-quality data the next time
 	# they ran, since all modes share one depth_texture/ImageTexture.
-	main.stream_backend.set_depth_model(1 if mode == 4 else (2 if mode == 5 else (3 if mode == 6 or mode == 7 or mode == 8 or mode == 9 else 0)))
+	main.stream_backend.set_depth_model(1 if mode == 4 else (3 if mode == 6 or mode == 7 or mode == 8 or mode == 9 else 0))
 
 func toggle_passthrough():
 	if not main.is_xr_active or not main.passthrough_supported:

--- a/src/settings_controller.gd
+++ b/src/settings_controller.gd
@@ -14,31 +14,30 @@ var sbs_labels: Array = ["Off", "Stretch", "Crop"]
 # so GPU isn't needed as a working comparison point anymore. Don't restore
 # a mapping for stereo_mode 5 without re-adding that code.
 # The original "MiDaS" mode (a single-sample parallax shift, stereo_mode 3)
-# is REMOVED too (2026-08-18) - once MiDaS-Fast (below) reached similar
-# quality at similar performance on-device, there was no reason to keep the
-# cruder mode around. stereo_mode 3/4's shader branch in yuv_display.gdshader
-# is dead code left in place (harmless, costs nothing unless selected) rather
-# than deleted - see stereo_mode 4/5's own history for the same pattern.
-# MiDaS-Fast (stereo_mode 10) is the same occlusion-aware warp as MiDaS-Std
-# (stereo_mode 6, same model/inference), but with its upsample/offset warp
-# passes throttled + shrunk (EX_PASS_DIVISOR) and the per-eye Newton
-# refinement in yuv_display.gdshader amortized to every other frame - see
-# warp_update_interval's comment in depth_estimator.gd for the full
-# GPU-cost investigation this came out of. Confirmed on-device (2026-08-18)
-# to land near MiDaS-Std's quality at close to the old crude mode's
-# framerate. Kept as its own mode (not folded into MiDaS-Std) so MiDaS-Std
-# stays the unthrottled/known-good reference to compare against.
-# MiDaS-Fast comes before MiDaS-Std in the cycle order (not alphabetical/
-# quality order) so a first-time user cycling through options lands on the
-# faster mode first, rather than possibly judging performance off MiDaS-Std.
-# MiDaS-Fastest (stereo_mode 11, added 2026-08-18) pushes the same GPU-cost
-# knobs further still (FASTEST_PASS_DIVISOR=12, 1 Newton step every 3rd
-# frame instead of every 2nd - see WARP_NEWTON_PERIOD in depth_estimator.gd)
-# aimed at leaving headroom for 4K, where the per-eye Newton gather and the
-# pre-pass both cost more pixels than at the resolutions the other tiers
-# were tuned at. Put last in the cycle (after the known-good tiers) rather
-# than first, since it's the least proven of the three.
-var ai_3d_labels: Array = ["2D", "MiDaS-Fast", "MiDaS-Std", "MiDaS-Fastest", "MiDaS-DMap", "MiDaS-DMap-Raw", "MiDaS-DMap-Input"]
+# is REMOVED too (2026-08-18) - stereo_mode 3/4's shader branch in
+# yuv_display.gdshader is dead code left in place (harmless, costs nothing
+# unless selected) rather than deleted - see stereo_mode 4/5's own history
+# for the same pattern.
+#
+# Split (2026-08-18) from a single flat "3D AI" cycle into three
+# independent controls, matching main.gd's ai_3d_model/ai_3d_quality/
+# ai_3d_debug:
+#   ai_3d_model_labels   - is AI-3D on at all, and with which model (more
+#                          models may join MiDaS here in future).
+#   ai_3d_quality_labels - which performance tier. Fastest/Fast/Standard
+#                          directly select depth_estimator.gd's warp_tier
+#                          2/1/0 (see MiDaS-Fast/-Fastest's own history in
+#                          main.gd, MIDAS_FAST_MAX_PIXELS, for what each
+#                          tier trades off). Auto instead picks a tier from
+#                          the current resolution/passthrough state - see
+#                          resolve_quality_tier()/_auto_quality_tier() below.
+#   ai_3d_debug_labels   - debug depth-data VIEWS (DMap/-Raw/-Input),
+#                          overlaid on whichever quality tier is active
+#                          rather than a mode of their own - see
+#                          get_stereo_mode() and _schedule_ai_3d_commit().
+var ai_3d_model_labels: Array = ["Off", "MiDaS"]
+var ai_3d_quality_labels: Array = ["Auto", "Fastest", "Fast", "Standard"]
+var ai_3d_debug_labels: Array = ["Off", "DMap", "DMap-Raw", "DMap-Input"]
 var idle_labels: Array = ["Off", "5m", "15m", "30m", "60m"]
 var idle_values: Array = [0, 5, 15, 30, 60]
 
@@ -48,22 +47,47 @@ func _init(owner: Node3D):
 func get_stereo_mode() -> int:
 	if main.sbs_mode > 0:
 		return main.sbs_mode
-	if main.ai_3d_mode == 0:
+	if main.ai_3d_model == 0:
 		return 0
-	elif main.ai_3d_mode == 1:
-		return 10 # MiDaS-Fast (throttled/shrunk warp passes)
-	elif main.ai_3d_mode == 2:
-		return 6 # MiDaS-Std
-	elif main.ai_3d_mode == 3:
-		return 11 # MiDaS-Fastest (throttled/shrunk further, for 4K)
-	elif main.ai_3d_mode == 4:
+	if main.ai_3d_debug == 1:
 		return 7 # MiDaS-DMap
-	elif main.ai_3d_mode == 5:
+	elif main.ai_3d_debug == 2:
 		return 8 # MiDaS-DMap-Raw
-	elif main.ai_3d_mode == 6:
+	elif main.ai_3d_debug == 3:
 		return 9 # MiDaS-DMap-Input
+	match resolve_quality_tier():
+		1: return 10 # MiDaS-Fast
+		2: return 11 # MiDaS-Fastest
+		_: return 6 # MiDaS-Std
+
+# 0=Standard, 1=Fast, 2=Fastest - matches depth_estimator.gd's warp_tier
+# numbering exactly, so apply_stereo() can pass this straight through.
+func resolve_quality_tier() -> int:
+	match main.ai_3d_quality:
+		1: return 2 # Fastest
+		2: return 1 # Fast
+		3: return 0 # Standard
+		_: return _auto_quality_tier()
+
+# Reads the pre-AI3D-cap BASE resolution (compute_requested_resolution(false),
+# NOT the live/possibly-already-capped value - reading the capped value
+# would be circular, since Auto's own tier choice is what determines the
+# cap in the first place) and classifies it by total pixel count against
+# the nearest 16:9 reference resolution, not literal width/height - this
+# setup's native_resolution is a wide multi-monitor composite, not 16:9,
+# and a literal-dimension check would misclassify it the same way the old
+# width/height-pair resolution caps did (see MIDAS_FAST_MAX_PIXELS's
+# history in main.gd).
+func _auto_quality_tier() -> int:
+	var res = main.compute_requested_resolution(false)
+	var pixels = res.x * res.y
+	var pt = main.passthrough_enabled
+	if pixels <= 1280 * 720:
+		return 0 # Standard, either passthrough state
+	elif pixels <= 2560 * 1440:
+		return 1 if pt else 0 # 1080p/1440p: Fast w/ passthrough, else Standard
 	else:
-		return 4
+		return 2 if pt else 1 # 4K+: Fastest w/ passthrough, else Fast
 
 func _save_setting(btn: Button, label: String):
 	if btn:
@@ -78,24 +102,38 @@ func cycle_sbs_mode():
 	if main.sbs_mode > 0 and main.screens.size() > 1:
 		main._ui_status_label.text = "SBS applies to primary screen only"
 
-func cycle_ai_3d_mode():
+func cycle_ai_3d_model():
 	if OS.get_name() != "Android":
 		return
 	if main.sbs_mode > 0:
 		return
-	# Debug views (MiDaS-DMap/-Raw/-Input, ai_3d_mode 4-6) re-enabled in the
-	# cycle (2026-08-18) to check 3D/depth quality while investigating the
-	# resolution-cap suspicion (see MIDAS_RES_CAP_ENABLED in main.gd). Drop
-	# back to % 4 to disable them again once that's settled.
 	# Only the label updates immediately - actually applying the mode
 	# (apply_stereo(), which reconfigures depth_estimator and can trigger a
 	# resolution-cap stream restart) is debounced below, same UX as
 	# cycle_resolution()/_schedule_stream_restart(): click through to find
-	# the mode you want, and it only commits once you stop, instead of
+	# the setting you want, and it only commits once you stop, instead of
 	# reconfiguring/restarting on every single click along the way.
-	main.ai_3d_mode = (main.ai_3d_mode + 1) % 7
-	_save_setting(main._ui_3d_btn, ai_3d_labels[main.ai_3d_mode])
+	main.ai_3d_model = (main.ai_3d_model + 1) % 2
+	_save_setting(main._ui_3d_btn, ai_3d_model_labels[main.ai_3d_model])
+	main.ui_controller.update_3d_btn_state()
 	_schedule_ai_3d_commit()
+
+func cycle_ai_3d_quality():
+	if OS.get_name() != "Android":
+		return
+	if main.sbs_mode > 0 or main.ai_3d_model == 0:
+		return
+	main.ai_3d_quality = (main.ai_3d_quality + 1) % 4
+	_save_setting(main._ui_3d_quality_btn, ai_3d_quality_labels[main.ai_3d_quality])
+	_schedule_ai_3d_commit()
+
+func cycle_ai_3d_debug():
+	# Disabled (2026-08-18), not removed - get_stereo_mode()/apply_stereo()/
+	# _schedule_ai_3d_commit() still fully handle ai_3d_debug != 0 correctly,
+	# and the button stays visible (just always disabled/dim - see
+	# ui_controller.gd's update_3d_btn_state()) rather than hidden. Delete
+	# this early return to re-enable clicking through DMap/-Raw/-Input again.
+	return
 
 func _schedule_ai_3d_commit():
 	_ai_3d_commit_seq += 1
@@ -103,21 +141,23 @@ func _schedule_ai_3d_commit():
 	# Shorter than _schedule_stream_restart()'s own 0.8s - this one's mostly
 	# used for fast click-through debugging (checking DMap/DMap-Raw/-Input
 	# against whichever tier is active), where quick feedback matters more
-	# than matching the restart delay exactly.
+	# than matching the restart delay exactly. Shared across all three
+	# cycle_ai_3d_*() functions above (one sequence counter), so clicking
+	# between model/quality/debug controls in quick succession still only
+	# commits once, for whatever the final combined state ends up being.
 	await main.get_tree().create_timer(0.6).timeout
 	if _ai_3d_commit_seq != my_seq:
 		return
-	var mode = get_stereo_mode()
-	# MiDaS-DMap/-Raw/-Input (7/8/9) are debug VIEWS of whatever depth data
-	# is already flowing, not a separate mode with its own resolution needs
-	# - deliberately inherit whatever resolution (including a MiDaS-Fast/
+	# MiDaS-DMap/-Raw/-Input are debug VIEWS of whatever depth data is
+	# already flowing, not a separate mode with its own resolution needs -
+	# deliberately inherit whatever resolution (including a MiDaS-Fast/
 	# -Fastest cap) is already active instead of recomputing/restarting back
 	# to the full uncapped resolution. That restart actively worked against
-	# debugging: switching to DMap to inspect what Fast/Fastest were doing
+	# debugging: switching to a debug view to inspect what a tier was doing
 	# changed the very thing being inspected (a different, uncapped
 	# resolution) and interrupted the stream to do it. They never restart,
 	# so apply_stereo() is always safe to call immediately here.
-	if mode == 7 or mode == 8 or mode == 9:
+	if main.ai_3d_debug != 0:
 		apply_stereo()
 		return
 	# MiDaS-Fast/-Fastest cap the actual requested stream resolution (see
@@ -164,15 +204,13 @@ func apply_stereo():
 		# model - also no warp passes needed. modes 10/11 (MiDaS-Fast/
 		# -Fastest) are the same warp passes as mode 6, just throttled/shrunk
 		# by differing amounts - see warp_update_interval's comment in
-		# depth_estimator.gd. warp_tier (0=full, 1=Fast, 2=Fastest) selects
-		# which; anything else defaults to tier 0 (no cost-cutting) inside
-		# set_enabled() itself.
-		var warp_tier := 0
-		if mode == 10:
-			warp_tier = 1
-		elif mode == 11:
-			warp_tier = 2
-		main.depth_estimator.set_enabled(mode >= 3, mode == 5 or mode == 6 or mode == 7 or mode == 10 or mode == 11, warp_tier)
+		# depth_estimator.gd. warp_tier (0=Standard, 1=Fast, 2=Fastest) comes
+		# from resolve_quality_tier() - the SAME tier drives the pre-pass
+		# config whether you're looking at the real warp (mode 6/10/11) or a
+		# debug view of it (mode 7/8/9), since debug views are just a lens
+		# on whichever tier is actually active, not a tier of their own.
+		var warp_tier = resolve_quality_tier() if main.ai_3d_model > 0 else 0
+		main.depth_estimator.set_enabled(mode >= 3, mode == 6 or mode == 7 or mode == 10 or mode == 11, warp_tier)
 		# switch_to_stereo_comp_layer() (called just above) unconditionally sets
 		# primary_screen.comp_viewport (the mono viewport, comp_shader_mat's
 		# always-stereo_mode=0 output) to UPDATE_DISABLED in favor of

--- a/src/settings_controller.gd
+++ b/src/settings_controller.gd
@@ -4,6 +4,7 @@ extends RefCounted
 var main: Node3D
 var _restart_pending: bool = false
 var _restart_seq: int = 0
+var _ai_3d_commit_seq: int = 0
 
 var sbs_labels: Array = ["Off", "Stretch", "Crop"]
 # MiDaS-GPU (stereo_mode 5) is REMOVED, not disabled - its underlying
@@ -82,27 +83,63 @@ func cycle_ai_3d_mode():
 		return
 	if main.sbs_mode > 0:
 		return
-	# Debug views (MiDaS-DMap/-Raw/-Input, ai_3d_mode 4-6) are disabled from
-	# cycling, not removed - their code/shader params are still wired up in
-	# get_stereo_mode()/apply_stereo() below so they can be re-enabled by
-	# bumping this modulo back to 7 whenever we're doing more work on the
-	# AI-3D pipeline and need to inspect the depth map again.
-	main.ai_3d_mode = (main.ai_3d_mode + 1) % 4
+	# Debug views (MiDaS-DMap/-Raw/-Input, ai_3d_mode 4-6) re-enabled in the
+	# cycle (2026-08-18) to check 3D/depth quality while investigating the
+	# resolution-cap suspicion (see MIDAS_RES_CAP_ENABLED in main.gd). Drop
+	# back to % 4 to disable them again once that's settled.
+	# Only the label updates immediately - actually applying the mode
+	# (apply_stereo(), which reconfigures depth_estimator and can trigger a
+	# resolution-cap stream restart) is debounced below, same UX as
+	# cycle_resolution()/_schedule_stream_restart(): click through to find
+	# the mode you want, and it only commits once you stop, instead of
+	# reconfiguring/restarting on every single click along the way.
+	main.ai_3d_mode = (main.ai_3d_mode + 1) % 7
 	_save_setting(main._ui_3d_btn, ai_3d_labels[main.ai_3d_mode])
-	apply_stereo()
+	_schedule_ai_3d_commit()
+
+func _schedule_ai_3d_commit():
+	_ai_3d_commit_seq += 1
+	var my_seq = _ai_3d_commit_seq
+	# Shorter than _schedule_stream_restart()'s own 0.8s - this one's mostly
+	# used for fast click-through debugging (checking DMap/DMap-Raw/-Input
+	# against whichever tier is active), where quick feedback matters more
+	# than matching the restart delay exactly.
+	await main.get_tree().create_timer(0.6).timeout
+	if _ai_3d_commit_seq != my_seq:
+		return
+	var mode = get_stereo_mode()
+	# MiDaS-DMap/-Raw/-Input (7/8/9) are debug VIEWS of whatever depth data
+	# is already flowing, not a separate mode with its own resolution needs
+	# - deliberately inherit whatever resolution (including a MiDaS-Fast/
+	# -Fastest cap) is already active instead of recomputing/restarting back
+	# to the full uncapped resolution. That restart actively worked against
+	# debugging: switching to DMap to inspect what Fast/Fastest were doing
+	# changed the very thing being inspected (a different, uncapped
+	# resolution) and interrupted the stream to do it. They never restart,
+	# so apply_stereo() is always safe to call immediately here.
+	if mode == 7 or mode == 8 or mode == 9:
+		apply_stereo()
+		return
 	# MiDaS-Fast/-Fastest cap the actual requested stream resolution (see
-	# MIDAS_FAST_MAX_RES in main.gd) - compute_requested_resolution() is
-	# keyed off get_stereo_mode(), which apply_stereo() just re-evaluated,
-	# so re-derive it here too. Only restart if it actually changed - most
-	# mode switches below 4K-ish source resolutions never hit either cap,
-	# and a restart mid-test is disruptive enough to avoid when it'd be a
-	# no-op anyway.
+	# MIDAS_FAST_MAX_PIXELS in main.gd). Checked BEFORE apply_stereo(), not
+	# after - if a restart is needed, apply_stereo() is skipped here
+	# entirely and left to main.gd's _on_stream_started(), which now calls
+	# it once the new session actually lands, instead of calling it here too
+	# and applying the new stereo/depth mode against the OLD, about-to-be-
+	# replaced video for the ~0.8-1.3s the restart takes. That was a real,
+	# visible bug (2026-08-18, user diagnosed it directly): the new effect
+	# would visibly apply and then get lost the moment the restart landed,
+	# since depth_estimator's pre-pass/warp state got initialized against a
+	# session that was seconds from being torn down, not the one that
+	# actually mattered.
 	var new_res = main.compute_requested_resolution()
 	if new_res != main.host_resolution:
 		main.host_resolution = new_res
 		refresh_resolution_btn_label()
 		if main.is_streaming:
 			_schedule_stream_restart()
+			return
+	apply_stereo()
 
 func apply_stereo():
 	var mode = get_stereo_mode()

--- a/src/settings_controller.gd
+++ b/src/settings_controller.gd
@@ -6,7 +6,7 @@ var _restart_pending: bool = false
 var _restart_seq: int = 0
 
 var sbs_labels: Array = ["Off", "Stretch", "Crop"]
-var ai_3d_labels: Array = ["2D", "MiDaS", "MiDaS-GPU", "MiDaS-NNAPI", "MiDaS-DMap"]
+var ai_3d_labels: Array = ["2D", "MiDaS", "MiDaS-GPU", "MiDaS-NNAPI", "MiDaS-DMap", "MiDaS-DMap-Raw", "MiDaS-DMap-Input"]
 var idle_labels: Array = ["Off", "5m", "15m", "30m", "60m"]
 var idle_values: Array = [0, 5, 15, 30, 60]
 
@@ -25,7 +25,11 @@ func get_stereo_mode() -> int:
 	elif main.ai_3d_mode == 3:
 		return 6
 	elif main.ai_3d_mode == 4:
-		return 7
+		return 7 # MiDaS-DMap
+	elif main.ai_3d_mode == 5:
+		return 8 # MiDaS-DMap-Raw
+	elif main.ai_3d_mode == 6:
+		return 9 # MiDaS-DMap-Input
 	else:
 		return 4
 
@@ -47,7 +51,7 @@ func cycle_ai_3d_mode():
 		return
 	if main.sbs_mode > 0:
 		return
-	main.ai_3d_mode = (main.ai_3d_mode + 1) % 5
+	main.ai_3d_mode = (main.ai_3d_mode + 1) % 7
 	_save_setting(main._ui_3d_btn, ai_3d_labels[main.ai_3d_mode])
 	apply_stereo()
 
@@ -66,25 +70,51 @@ func apply_stereo():
 	if main.screen_mesh.material_override is ShaderMaterial:
 		main.screen_mesh.material_override.set_shader_parameter("stereo_mode", mode)
 	if main.depth_estimator:
-		# mode 7 (MiDaS-DMap) now visualizes upsampled_depth_texture (the real
-		# post-upsample data the actual warp uses), not the raw pre-upsample
-		# depth_texture, so it needs the warp passes running too.
+		# mode 7 (MiDaS-DMap) visualizes upsampled_depth_texture (the real
+		# post-upsample data the actual warp uses), so it needs the warp
+		# passes running too. mode 8 (MiDaS-DMap-Raw) visualizes the raw
+		# pre-upsample depth_texture directly - no warp passes needed. mode 9
+		# (MiDaS-DMap-Input) visualizes the literal color capture fed to the
+		# model - also no warp passes needed.
 		main.depth_estimator.set_enabled(mode >= 3, mode == 5 or mode == 6 or mode == 7)
+		# switch_to_stereo_comp_layer() (called just above) unconditionally sets
+		# primary_screen.comp_viewport (the mono viewport, comp_shader_mat's
+		# always-stereo_mode=0 output) to UPDATE_DISABLED in favor of
+		# comp_viewport_left/right - but that mono viewport is depth capture's
+		# ONLY semantically correct source (see bind_stream_texture()'s own
+		# comment for why comp_viewport_left doesn't work). Force it back to
+		# UPDATE_ALWAYS whenever depth capture needs it, undoing that disable
+		# every time this runs (switch_to_stereo_comp_layer() re-disables it
+		# on every call, so this has to re-assert every time too, not once).
+		if mode >= 3:
+			if main.primary_screen and main.primary_screen.comp_viewport:
+				main.primary_screen.comp_viewport.render_target_update_mode = SubViewport.UPDATE_ALWAYS
+			main.depth_estimator.bind_stream_texture()
 		if mode >= 3 and main.depth_estimator.depth_texture:
 			var de = main.depth_estimator
 			var upsampled_tex = de.upsample_viewport.get_texture() if de.upsample_viewport else null
 			var offset_tex = de.offset_viewport.get_texture() if de.offset_viewport else null
+			var guide_tex = de.depth_viewport.get_texture() if de.depth_viewport else null
 			if main.comp_shader_mat_left:
 				main.comp_shader_mat_left.set_shader_parameter("depth_texture", de.depth_texture)
 				main.comp_shader_mat_left.set_shader_parameter("upsampled_depth_texture", upsampled_tex)
 				main.comp_shader_mat_left.set_shader_parameter("offset_texture", offset_tex)
+				main.comp_shader_mat_left.set_shader_parameter("depth_guide_texture", guide_tex)
 			if main.comp_shader_mat_right:
 				main.comp_shader_mat_right.set_shader_parameter("depth_texture", de.depth_texture)
 				main.comp_shader_mat_right.set_shader_parameter("upsampled_depth_texture", upsampled_tex)
 				main.comp_shader_mat_right.set_shader_parameter("offset_texture", offset_tex)
-	# mode 7 (MiDaS-DMap) reuses the MiDaS-NNAPI model/inference (index 3) - it's
-	# a pure visualization of that same depth data, not a separate source.
-	main.stream_backend.set_depth_model(1 if mode == 4 else (2 if mode == 5 else (3 if mode == 6 or mode == 7 else 0)))
+				main.comp_shader_mat_right.set_shader_parameter("depth_guide_texture", guide_tex)
+	# modes 7/8/9 (MiDaS-DMap, MiDaS-DMap-Raw, MiDaS-DMap-Input) all reuse the
+	# MiDaS-NNAPI model/inference (index 3) - they're pure visualizations of
+	# that same depth data at different pipeline stages, not a separate
+	# source. mode 9 doesn't even read the model's output (just the color
+	# capture), but MUST still stay on model index 3 here - leaving it out of
+	# this set previously silently swapped the active model down to the slow
+	# CPU/dilate-blur path (index 0) every time mode 9 was selected, which
+	# then poisoned modes 6/7/8 with stale/wrong-quality data the next time
+	# they ran, since all modes share one depth_texture/ImageTexture.
+	main.stream_backend.set_depth_model(1 if mode == 4 else (2 if mode == 5 else (3 if mode == 6 or mode == 7 or mode == 8 or mode == 9 else 0)))
 
 func toggle_passthrough():
 	if not main.is_xr_active or not main.passthrough_supported:

--- a/src/settings_controller.gd
+++ b/src/settings_controller.gd
@@ -30,7 +30,14 @@ var sbs_labels: Array = ["Off", "Stretch", "Crop"]
 # MiDaS-Fast comes before MiDaS-Std in the cycle order (not alphabetical/
 # quality order) so a first-time user cycling through options lands on the
 # faster mode first, rather than possibly judging performance off MiDaS-Std.
-var ai_3d_labels: Array = ["2D", "MiDaS-Fast", "MiDaS-Std", "MiDaS-DMap", "MiDaS-DMap-Raw", "MiDaS-DMap-Input"]
+# MiDaS-Fastest (stereo_mode 11, added 2026-08-18) pushes the same GPU-cost
+# knobs further still (FASTEST_PASS_DIVISOR=12, 1 Newton step every 3rd
+# frame instead of every 2nd - see WARP_NEWTON_PERIOD in depth_estimator.gd)
+# aimed at leaving headroom for 4K, where the per-eye Newton gather and the
+# pre-pass both cost more pixels than at the resolutions the other tiers
+# were tuned at. Put last in the cycle (after the known-good tiers) rather
+# than first, since it's the least proven of the three.
+var ai_3d_labels: Array = ["2D", "MiDaS-Fast", "MiDaS-Std", "MiDaS-Fastest", "MiDaS-DMap", "MiDaS-DMap-Raw", "MiDaS-DMap-Input"]
 var idle_labels: Array = ["Off", "5m", "15m", "30m", "60m"]
 var idle_values: Array = [0, 5, 15, 30, 60]
 
@@ -47,10 +54,12 @@ func get_stereo_mode() -> int:
 	elif main.ai_3d_mode == 2:
 		return 6 # MiDaS-Std
 	elif main.ai_3d_mode == 3:
-		return 7 # MiDaS-DMap
+		return 11 # MiDaS-Fastest (throttled/shrunk further, for 4K)
 	elif main.ai_3d_mode == 4:
-		return 8 # MiDaS-DMap-Raw
+		return 7 # MiDaS-DMap
 	elif main.ai_3d_mode == 5:
+		return 8 # MiDaS-DMap-Raw
+	elif main.ai_3d_mode == 6:
 		return 9 # MiDaS-DMap-Input
 	else:
 		return 4
@@ -73,14 +82,27 @@ func cycle_ai_3d_mode():
 		return
 	if main.sbs_mode > 0:
 		return
-	# Debug views (MiDaS-DMap/-Raw/-Input, ai_3d_mode 3-5) are disabled from
+	# Debug views (MiDaS-DMap/-Raw/-Input, ai_3d_mode 4-6) are disabled from
 	# cycling, not removed - their code/shader params are still wired up in
 	# get_stereo_mode()/apply_stereo() below so they can be re-enabled by
-	# bumping this modulo back to 6 whenever we're doing more work on the
+	# bumping this modulo back to 7 whenever we're doing more work on the
 	# AI-3D pipeline and need to inspect the depth map again.
-	main.ai_3d_mode = (main.ai_3d_mode + 1) % 3
+	main.ai_3d_mode = (main.ai_3d_mode + 1) % 4
 	_save_setting(main._ui_3d_btn, ai_3d_labels[main.ai_3d_mode])
 	apply_stereo()
+	# MiDaS-Fast/-Fastest cap the actual requested stream resolution (see
+	# MIDAS_FAST_MAX_RES in main.gd) - compute_requested_resolution() is
+	# keyed off get_stereo_mode(), which apply_stereo() just re-evaluated,
+	# so re-derive it here too. Only restart if it actually changed - most
+	# mode switches below 4K-ish source resolutions never hit either cap,
+	# and a restart mid-test is disruptive enough to avoid when it'd be a
+	# no-op anyway.
+	var new_res = main.compute_requested_resolution()
+	if new_res != main.host_resolution:
+		main.host_resolution = new_res
+		refresh_resolution_btn_label()
+		if main.is_streaming:
+			_schedule_stream_restart()
 
 func apply_stereo():
 	var mode = get_stereo_mode()
@@ -102,10 +124,18 @@ func apply_stereo():
 		# passes running too. mode 8 (MiDaS-DMap-Raw) visualizes the raw
 		# pre-upsample depth_texture directly - no warp passes needed. mode 9
 		# (MiDaS-DMap-Input) visualizes the literal color capture fed to the
-		# model - also no warp passes needed. mode 10 (MiDaS-Fast) is the same
-		# warp passes as mode 6, just throttled - see warp_update_interval's
-		# comment in depth_estimator.gd.
-		main.depth_estimator.set_enabled(mode >= 3, mode == 5 or mode == 6 or mode == 7 or mode == 10, mode == 10)
+		# model - also no warp passes needed. modes 10/11 (MiDaS-Fast/
+		# -Fastest) are the same warp passes as mode 6, just throttled/shrunk
+		# by differing amounts - see warp_update_interval's comment in
+		# depth_estimator.gd. warp_tier (0=full, 1=Fast, 2=Fastest) selects
+		# which; anything else defaults to tier 0 (no cost-cutting) inside
+		# set_enabled() itself.
+		var warp_tier := 0
+		if mode == 10:
+			warp_tier = 1
+		elif mode == 11:
+			warp_tier = 2
+		main.depth_estimator.set_enabled(mode >= 3, mode == 5 or mode == 6 or mode == 7 or mode == 10 or mode == 11, warp_tier)
 		# switch_to_stereo_comp_layer() (called just above) unconditionally sets
 		# primary_screen.comp_viewport (the mono viewport, comp_shader_mat's
 		# always-stereo_mode=0 output) to UPDATE_DISABLED in favor of
@@ -134,17 +164,17 @@ func apply_stereo():
 				main.comp_shader_mat_right.set_shader_parameter("upsampled_depth_texture", upsampled_tex)
 				main.comp_shader_mat_right.set_shader_parameter("offset_texture", offset_tex)
 				main.comp_shader_mat_right.set_shader_parameter("depth_guide_texture", guide_tex)
-	# modes 6/7/8/9/10 (MiDaS-Std, MiDaS-DMap, MiDaS-DMap-Raw, MiDaS-DMap-
-	# Input, MiDaS-Fast) all reuse the same MiDaS-Std model/inference (index
-	# 3) - they're pure visualizations/warp-pass variants of that same depth
-	# data, not a separate source. mode 9 doesn't even read the model's
-	# output (just the color capture), but MUST still stay on model index 3
-	# here - leaving it out of this set previously silently swapped the
-	# active model down to the slow CPU/dilate-blur path (index 0) every
-	# time mode 9 was selected, which then poisoned the other modes with
-	# stale/wrong-quality data the next time they ran, since all modes share
-	# one depth_texture/ImageTexture.
-	main.stream_backend.set_depth_model(1 if mode == 4 else (3 if mode == 6 or mode == 7 or mode == 8 or mode == 9 or mode == 10 else 0))
+	# modes 6/7/8/9/10/11 (MiDaS-Std, MiDaS-DMap, MiDaS-DMap-Raw, MiDaS-DMap-
+	# Input, MiDaS-Fast, MiDaS-Fastest) all reuse the same MiDaS-Std model/
+	# inference (index 3) - they're pure visualizations/warp-pass variants of
+	# that same depth data, not a separate source. mode 9 doesn't even read
+	# the model's output (just the color capture), but MUST still stay on
+	# model index 3 here - leaving it out of this set previously silently
+	# swapped the active model down to the slow CPU/dilate-blur path (index
+	# 0) every time mode 9 was selected, which then poisoned the other modes
+	# with stale/wrong-quality data the next time they ran, since all modes
+	# share one depth_texture/ImageTexture.
+	main.stream_backend.set_depth_model(1 if mode == 4 else (3 if mode == 6 or mode == 7 or mode == 8 or mode == 9 or mode == 10 or mode == 11 else 0))
 
 func toggle_passthrough():
 	if not main.is_xr_active or not main.passthrough_supported:

--- a/src/shaders/depth_downscale.gdshader
+++ b/src/shaders/depth_downscale.gdshader
@@ -1,0 +1,17 @@
+shader_type canvas_item;
+
+// Plain fragment-shader downscale of comp_viewport into depth_viewport
+// (256x256), replacing a TextureRect+STRETCH_SCALE that showed a
+// persistent, unexplained crop to a sub-region of the frame despite the
+// bound texture's RID being verified identical to comp_viewport's own
+// texture - a TextureRect can cache the source texture's reported size for
+// its stretch-mode math and not always notice a live ViewportTexture's
+// underlying content being resized later (comp_viewport gets resized
+// dynamically as the real stream resolution negotiates in). Sampling
+// directly here has no such cache - COLOR is recomputed fresh from
+// source_tex's CURRENT size every render frame, every time.
+uniform sampler2D source_tex : filter_linear_mipmap, repeat_disable;
+
+void fragment() {
+	COLOR = texture(source_tex, UV);
+}

--- a/src/shaders/depth_offset.gdshader
+++ b/src/shaders/depth_offset.gdshader
@@ -5,12 +5,19 @@ shader_type canvas_item;
 // Gilleece/moonlight-android-xr's xr_renderer.c OFFSET_FRAGMENT_SRC:
 // inverts the warp properly by searching, for this destination pixel,
 // which source offset t actually satisfies
-//   e(t) = t - disparity * (depth(here + t) - convergence) = 0
+//   e(t) = t + disparity * (depth(here + t) - convergence) = 0
 // Every zero crossing is a source pixel that genuinely lands here; when more
 // than one does (an occlusion), the nearer surface (larger depth) wins -
 // this is what a single forward shift can never resolve, and why it
 // stretches/smears across depth discontinuities instead of keeping small
 // objects visually separate from what's behind them.
+//
+// The sign here (+disp, not -disp) matches the reference exactly - getting
+// this backwards doesn't crash or look obviously broken, it just searches
+// in the wrong direction, which shows up as the post-upsample warp (and
+// DMap, which visualizes this same data) looking WORSE than the raw
+// unprocessed depth instead of better. Verified against xr_renderer.c
+// directly (see git history 2026-08) rather than re-derived from scratch.
 
 uniform sampler2D upsampled_depth_texture : hint_default_white, filter_linear;
 // disparity, in this pass's own texels: parallax_fraction * this_pass_width
@@ -29,13 +36,13 @@ void fragment() {
 	for (int eye = 0; eye < 2; eye++) {
 		float disp = (eye == 0) ? disp_texels : -disp_texels;
 		float here = texelFetch(upsampled_depth_texture, ivec2(x, y), 0).r;
-		float best_off = disp * (here - convergence);
+		float best_off = -disp * (here - convergence);
 		float best_d = -1.0;
 		float pd = texelFetch(upsampled_depth_texture, ivec2(clamp(x - reach, 0, sz.x - 1), y), 0).r;
-		float pe = float(-reach) - disp * (pd - convergence);
+		float pe = float(-reach) + disp * (pd - convergence);
 		for (int t = -reach + 1; t <= reach; t++) {
 			float cd = texelFetch(upsampled_depth_texture, ivec2(clamp(x + t, 0, sz.x - 1), y), 0).r;
-			float ce = float(t) - disp * (cd - convergence);
+			float ce = float(t) + disp * (cd - convergence);
 			float span = ce - pe;
 			if (pe * ce <= 0.0 && abs(span) > 1e-6) {
 				float f = clamp(-pe / span, 0.0, 1.0);

--- a/src/shaders/depth_offset.gdshader
+++ b/src/shaders/depth_offset.gdshader
@@ -1,0 +1,54 @@
+shader_type canvas_item;
+
+// Runs once per frame (not per eye) at the same resolution as
+// depth_upsample.gdshader's output, reading it directly. Ported from
+// Gilleece/moonlight-android-xr's xr_renderer.c OFFSET_FRAGMENT_SRC:
+// inverts the warp properly by searching, for this destination pixel,
+// which source offset t actually satisfies
+//   e(t) = t - disparity * (depth(here + t) - convergence) = 0
+// Every zero crossing is a source pixel that genuinely lands here; when more
+// than one does (an occlusion), the nearer surface (larger depth) wins -
+// this is what a single forward shift can never resolve, and why it
+// stretches/smears across depth discontinuities instead of keeping small
+// objects visually separate from what's behind them.
+
+uniform sampler2D upsampled_depth_texture : hint_default_white, filter_linear;
+// disparity, in this pass's own texels: parallax_fraction * this_pass_width
+uniform float disp_texels = 10.0;
+uniform float convergence = 0.5;
+
+void fragment() {
+	ivec2 sz = textureSize(upsampled_depth_texture, 0);
+	int x = int(FRAGCOORD.x);
+	int y = int(FRAGCOORD.y);
+	int reach = int(ceil(abs(disp_texels) * max(convergence, 1.0 - convergence))) + 2;
+
+	vec2 result = vec2(0.0);
+	// eye 0 = left (positive disparity), eye 1 = right (negative) - matches
+	// yuv_display.gdshader's is_left ? +parallax : -parallax convention.
+	for (int eye = 0; eye < 2; eye++) {
+		float disp = (eye == 0) ? disp_texels : -disp_texels;
+		float here = texelFetch(upsampled_depth_texture, ivec2(x, y), 0).r;
+		float best_off = disp * (here - convergence);
+		float best_d = -1.0;
+		float pd = texelFetch(upsampled_depth_texture, ivec2(clamp(x - reach, 0, sz.x - 1), y), 0).r;
+		float pe = float(-reach) - disp * (pd - convergence);
+		for (int t = -reach + 1; t <= reach; t++) {
+			float cd = texelFetch(upsampled_depth_texture, ivec2(clamp(x + t, 0, sz.x - 1), y), 0).r;
+			float ce = float(t) - disp * (cd - convergence);
+			float span = ce - pe;
+			if (pe * ce <= 0.0 && abs(span) > 1e-6) {
+				float f = clamp(-pe / span, 0.0, 1.0);
+				float rd = pd + f * (cd - pd);
+				if (rd > best_d) {
+					best_d = rd;
+					best_off = float(t - 1) + f;
+				}
+			}
+			pd = cd;
+			pe = ce;
+		}
+		result[eye] = best_off;
+	}
+	COLOR = vec4(result / (2.0 * float(reach)) + 0.5, 0.0, 1.0);
+}

--- a/src/shaders/depth_upsample.gdshader
+++ b/src/shaders/depth_upsample.gdshader
@@ -1,0 +1,148 @@
+shader_type canvas_item;
+
+// Runs once per frame (not per eye) at a modest fraction of the stream's own
+// resolution - see depth_estimator.gd for the sizing. Ported from
+// Gilleece/moonlight-android-xr's xr_renderer.c UPSAMPLE_FRAGMENT_SRC: a
+// joint bilateral upsample of the depth model's raw 256x256 output, guided
+// by the real decoded color frame, so depth edges snap to color edges
+// instead of the raw output's blurry ones (which is what made small objects
+// like a taskbar icon or a clock widget stretch/warp instead of standing
+// apart from the background).
+//
+// Decodes YUV directly (duplicated from yuv_display.gdshader) rather than
+// depending on comp_viewport's rendered RGB output. comp_viewport is itself
+// a SubViewport, and Godot updates SubViewports in scene-tree order - since
+// THIS pass's own output is a dependency of comp_viewport_left/right (the
+// actually-displayed eyes, via yuv_display.gdshader's stereo_mode 5 branch),
+// this pass must render BEFORE them, which conflicts with also needing to
+// render AFTER comp_viewport if comp_viewport were the color source. tex_y/
+// tex_u/tex_v are plain uploaded textures with no such render-order
+// dependency, so sourcing color from them directly breaks the cycle.
+
+uniform sampler2D tex_y : filter_linear, repeat_disable;
+uniform sampler2D tex_u : filter_linear, repeat_disable;
+uniform sampler2D tex_v : filter_linear, repeat_disable;
+uniform int yuv_mode = 0;
+uniform int color_matrix_type = 1;
+uniform int color_range = 0;
+uniform sampler2D main_texture : source_color, filter_linear, repeat_disable;
+uniform vec4 uv_region = vec4(0.0, 0.0, 1.0, 1.0);
+uniform vec2 tile_inset = vec2(0.002);
+
+uniform sampler2D depth_texture : hint_default_white, filter_linear;
+// Low-res (same resolution as depth_texture) downscaled color frame the
+// depth model itself saw - the neighbour-comparison guide. Kept separate
+// from the full-res "here" comparison so the 5x5 neighbour taps stay cheap
+// texelFetches instead of 25 extra full-res texture() samples.
+uniform sampler2D depth_guide_texture : hint_default_black, filter_linear;
+// Matches Gilleece/moonlight-android-xr's own measured/shipped defaults
+// (xr_renderer.c) exactly, not guesses: sigma_r=0.25 was "measured best on a
+// captured frame: same 5px edge as tighter values with a tenth of the
+// speckle" (a tighter sigma_r, which is what this had before, gives the same
+// edge sharpness but far noisier depth); sharp=0.0 (the hard edge-snap
+// below) was tested and shipped OFF - "off until it earns its place in a
+// blind comparison on device."
+uniform float sigma_r = 0.25;
+uniform float sharp = 0.0;
+
+vec3 yuv_to_rgb(vec2 uv) {
+	if (color_matrix_type == 3) {
+		return texture(tex_y, uv).rgb;
+	}
+
+	float y_raw = texture(tex_y, uv).r;
+	float u_raw = 0.5;
+	float v_raw = 0.5;
+
+	if (yuv_mode == 1) {
+		ivec2 tex_size = textureSize(tex_u, 0);
+		int cx = int(uv.x * float(tex_size.x / 2));
+		int cy = int(uv.y * float(tex_size.y));
+		cx = clamp(cx, 0, tex_size.x / 2 - 1);
+		cy = clamp(cy, 0, tex_size.y - 1);
+		u_raw = texelFetch(tex_u, ivec2(cx * 2, cy), 0).r;
+		v_raw = texelFetch(tex_u, ivec2(cx * 2 + 1, cy), 0).r;
+	} else if (yuv_mode == 2) {
+		vec2 uv_val = texture(tex_u, uv).rg;
+		u_raw = uv_val.r;
+		v_raw = uv_val.g;
+	} else if (yuv_mode == 3) {
+		u_raw = texture(tex_u, uv).r;
+		v_raw = texture(tex_v, uv).r;
+	}
+
+	float y, u, v;
+	if (color_range == 0) {
+		y = (y_raw - 16.0/255.0) * (255.0/219.0);
+		u = (u_raw - 128.0/255.0) * (255.0/224.0);
+		v = (v_raw - 128.0/255.0) * (255.0/224.0);
+	} else {
+		y = y_raw;
+		u = u_raw - 0.5;
+		v = v_raw - 0.5;
+	}
+
+	vec3 rgb = vec3(0.0);
+	if (color_matrix_type == 1) {
+		rgb.r = y + 1.5748 * v;
+		rgb.g = y - 0.1873 * u - 0.4681 * v;
+		rgb.b = y + 1.8556 * u;
+	} else if (color_matrix_type == 2) {
+		rgb.r = y + 1.4746 * v;
+		rgb.g = y - 0.16455 * u - 0.57135 * v;
+		rgb.b = y + 1.8814 * u;
+	} else {
+		rgb.r = y + 1.402 * v;
+		rgb.g = y - 0.344136 * u - 0.714136 * v;
+		rgb.b = y + 1.772 * u;
+	}
+	return rgb;
+}
+
+vec2 to_frame_uv(vec2 t) {
+	return uv_region.xy + clamp(t, tile_inset, vec2(1.0) - tile_inset) * uv_region.zw;
+}
+
+vec3 sample_stream(vec2 uv) {
+	if (yuv_mode > 0) {
+		return yuv_to_rgb(uv);
+	}
+	return texture(main_texture, uv).rgb;
+}
+
+void fragment() {
+	vec3 hi = sample_stream(to_frame_uv(UV));
+	ivec2 low_sz = textureSize(depth_texture, 0);
+	float n = float(low_sz.x);
+	vec2 lp = UV * n - 0.5;
+	ivec2 base = ivec2(floor(lp));
+
+	float num = 0.0;
+	float den = 0.0;
+	float dlo = 1.0;
+	float dhi = 0.0;
+	for (int dy = -2; dy <= 2; dy++) {
+		for (int dx = -2; dx <= 2; dx++) {
+			ivec2 q = clamp(base + ivec2(dx, dy), ivec2(0), ivec2(int(n) - 1));
+			float s = texelFetch(depth_texture, q, 0).r;
+			vec3 gcol = texelFetch(depth_guide_texture, q, 0).rgb;
+			vec2 off = vec2(q) - lp;
+			float ws = exp(-dot(off, off) / (2.0 * 1.5 * 1.5));
+			vec3 cd = hi - gcol;
+			float wr = exp(-dot(cd, cd) / (2.0 * sigma_r * sigma_r));
+			float w = ws * wr;
+			num += w * s;
+			den += w;
+			dlo = min(dlo, s);
+			dhi = max(dhi, s);
+		}
+	}
+	float d = num / max(den, 1e-6);
+	float span = dhi - dlo;
+	if (sharp > 0.0 && span >= 0.05) {
+		float u2 = clamp((d - dlo) / max(span, 1e-6), 0.0, 1.0);
+		float snapped = dlo + span / (1.0 + exp(-24.0 * (u2 - 0.5)));
+		d = mix(d, snapped, sharp);
+	}
+	COLOR = vec4(d, d, d, 1.0);
+}

--- a/src/shaders/stereo_screen.gdshader
+++ b/src/shaders/stereo_screen.gdshader
@@ -119,6 +119,63 @@ vec3 cas_sharpen_stream(vec2 uv, float strength) {
 	return c + weight * (c - avg);
 }
 
+// Classic 5-stop jet-style heatmap (blue -> cyan -> green -> yellow -> red)
+// for visualizing a scalar depth value - matches yuv_display.gdshader's own
+// heatmap(), duplicated here since this shader has no shared include.
+vec3 heatmap(float t) {
+	t = clamp(t, 0.0, 1.0);
+	vec3 c1 = vec3(0.0, 0.0, 1.0);
+	vec3 c2 = vec3(0.0, 1.0, 1.0);
+	vec3 c3 = vec3(0.0, 1.0, 0.0);
+	vec3 c4 = vec3(1.0, 1.0, 0.0);
+	vec3 c5 = vec3(1.0, 0.0, 0.0);
+	if (t < 0.25) {
+		return mix(c1, c2, t / 0.25);
+	} else if (t < 0.5) {
+		return mix(c2, c3, (t - 0.25) / 0.25);
+	} else if (t < 0.75) {
+		return mix(c3, c4, (t - 0.5) / 0.25);
+	} else {
+		return mix(c4, c5, (t - 0.75) / 0.25);
+	}
+}
+
+// Joint bilateral tap: weight each low-res depth neighbour by how closely
+// its guide color matches the real color at `uv`, so the depth edge snaps
+// to the color edge instead of straddling it. Shared by the mode 5/6/10/11
+// warp below (which also needs dlo/dhi for its edge-snap) and mode 7
+// (MiDaS-DMap), which visualizes this exact interpolated value as a heatmap
+// instead of using it to warp.
+float bilateral_depth(vec2 uv, out float dlo, out float dhi) {
+	ivec2 low_sz = textureSize(depth_texture, 0);
+	float n = float(low_sz.x);
+	vec3 hi_color = sample_stream(uv);
+	vec2 lp = uv * n - 0.5;
+	ivec2 base = ivec2(floor(lp));
+
+	float num = 0.0;
+	float den = 0.0;
+	dlo = 1.0;
+	dhi = 0.0;
+	for (int dy = -2; dy <= 2; dy++) {
+		for (int dx = -2; dx <= 2; dx++) {
+			ivec2 q = clamp(base + ivec2(dx, dy), ivec2(0), ivec2(int(n) - 1));
+			float s = texelFetch(depth_texture, q, 0).r;
+			vec3 gcol = texelFetch(depth_guide_texture, q, 0).rgb;
+			vec2 off = vec2(q) - lp;
+			float ws = exp(-dot(off, off) / (2.0 * 1.5 * 1.5));
+			vec3 cd = hi_color - gcol;
+			float wr = exp(-dot(cd, cd) / (2.0 * 0.12 * 0.12));
+			float w = ws * wr;
+			num += w * s;
+			den += w;
+			dlo = min(dlo, s);
+			dhi = max(dhi, s);
+		}
+	}
+	return num / max(den, 1e-6);
+}
+
 vec3 filtered_stream(vec2 uv) {
 	vec3 original = sample_stream(uv);
 
@@ -212,7 +269,7 @@ void fragment() {
 		vec2 src_uv = vec2(clamp(uv.x - shift * eye_sign, 0.0, 1.0), uv.y);
 		ALBEDO = filtered_stream(src_uv);
 	}
-	else if (stereo_mode == 5 || stereo_mode == 6) {
+	else if (stereo_mode == 5 || stereo_mode == 6 || stereo_mode == 10 || stereo_mode == 11) {
 		// Joint-bilateral-upsampled, occlusion-aware warp (MiDaS-GPU path).
 		// The plain branch above samples one raw, blurry low-res depth texel
 		// per destination pixel and always trusts it - correct only where
@@ -230,39 +287,24 @@ void fragment() {
 		// occlusion branch), collapsed into one pass since Godot's per-eye
 		// fragment shader here doesn't have a cheap way to share a
 		// pre-pass between the two eye invocations.
+		//
+		// stereo_mode 10/11 (MiDaS-Fast/-Fastest) get the exact same
+		// treatment as 6 (Std) here - this single-pass mesh-rendering
+		// fallback (used when comp.available is false) has no equivalent to
+		// depth_estimator.gd's tiered pre-pass throttling/shrinking or
+		// yuv_display.gdshader's warp_newton_steps amortization, so there's
+		// no cheaper version of this warp to give them; full quality is the
+		// only quality this path has.
 		float parallax = 0.042;
 		ivec2 low_sz = textureSize(depth_texture, 0);
 		float n = float(low_sz.x);
 		float texel = 1.0 / n;
 
-		vec3 hi_color = sample_stream(uv);
 		vec2 lp = uv * n - 0.5;
 		ivec2 base = ivec2(floor(lp));
 
-		// 5x5 joint bilateral tap: weight each low-res depth neighbour by
-		// how closely its guide color matches the real color here, so the
-		// depth edge snaps to the color edge instead of straddling it.
-		float num = 0.0;
-		float den = 0.0;
-		float dlo = 1.0;
-		float dhi = 0.0;
-		for (int dy = -2; dy <= 2; dy++) {
-			for (int dx = -2; dx <= 2; dx++) {
-				ivec2 q = clamp(base + ivec2(dx, dy), ivec2(0), ivec2(int(n) - 1));
-				float s = texelFetch(depth_texture, q, 0).r;
-				vec3 gcol = texelFetch(depth_guide_texture, q, 0).rgb;
-				vec2 off = vec2(q) - lp;
-				float ws = exp(-dot(off, off) / (2.0 * 1.5 * 1.5));
-				vec3 cd = hi_color - gcol;
-				float wr = exp(-dot(cd, cd) / (2.0 * 0.12 * 0.12));
-				float w = ws * wr;
-				num += w * s;
-				den += w;
-				dlo = min(dlo, s);
-				dhi = max(dhi, s);
-			}
-		}
-		float depth_here = num / max(den, 1e-6);
+		float dlo, dhi;
+		float depth_here = bilateral_depth(uv, dlo, dhi);
 		float span = dhi - dlo;
 		if (span >= 0.05) {
 			float edge_u = clamp((depth_here - dlo) / max(span, 1e-6), 0.0, 1.0);
@@ -306,5 +348,27 @@ void fragment() {
 
 		vec2 src_uv = vec2(clamp(uv.x + best_off, 0.0, 1.0), uv.y);
 		ALBEDO = filtered_stream(src_uv);
+	}
+	else if (stereo_mode == 7) {
+		// MiDaS-DMap: the bilateral-upsampled depth the real warp above
+		// (mode 5/6/10/11) actually consumes, as a heatmap instead of used
+		// to warp - matches yuv_display.gdshader's stereo_mode 7, except
+		// that path reads a precomputed upsampled_depth_texture while this
+		// one recomputes bilateral_depth() inline, since this shader has no
+		// equivalent precomputed pass to read from.
+		float dlo, dhi;
+		float d = bilateral_depth(uv, dlo, dhi);
+		ALBEDO = heatmap(d);
+	}
+	else if (stereo_mode == 8) {
+		// MiDaS-DMap-Raw: the RAW pre-upsample depth_texture (the model's
+		// actual 256x256 output), no bilateral upsample applied.
+		float d = texture(depth_texture, uv).r;
+		ALBEDO = heatmap(d);
+	}
+	else if (stereo_mode == 9) {
+		// MiDaS-DMap-Input: the literal color capture fed to the model, no
+		// heatmap, no processing at all.
+		ALBEDO = texture(depth_guide_texture, uv).rgb;
 	}
 }

--- a/src/shaders/stereo_screen.gdshader
+++ b/src/shaders/stereo_screen.gdshader
@@ -3,6 +3,10 @@ render_mode unshaded;
 
 uniform sampler2D main_texture : source_color, filter_linear, repeat_disable;
 uniform sampler2D depth_texture : hint_default_white, filter_linear_mipmap;
+// Same-resolution downscaled color frame the depth model itself saw
+// (depth_estimator.gd's depth_viewport) - used as the edge guide for
+// stereo_mode 5's joint bilateral depth upsample.
+uniform sampler2D depth_guide_texture : hint_default_black, filter_linear;
 uniform int stereo_mode = 0;
 uniform float convergence = 0.5;
 uniform float balance_shift = 0.5;
@@ -206,6 +210,101 @@ void fragment() {
 		shift *= vignette;
 
 		vec2 src_uv = vec2(clamp(uv.x - shift * eye_sign, 0.0, 1.0), uv.y);
+		ALBEDO = filtered_stream(src_uv);
+	}
+	else if (stereo_mode == 5 || stereo_mode == 6) {
+		// Joint-bilateral-upsampled, occlusion-aware warp (MiDaS-GPU path).
+		// The plain branch above samples one raw, blurry low-res depth texel
+		// per destination pixel and always trusts it - correct only where
+		// depth is flat, and wrong by most of the disparity range at a depth
+		// step, which is what makes small objects (taskbar icons, a clock
+		// widget) stretch/warp instead of standing apart from the background.
+		// This instead (a) snaps the low-res depth to the real color edges
+		// via a bilateral upsample, guided by depth_guide_texture - the same
+		// downscaled frame the depth model itself saw - and (b) searches a
+		// short span along the epipolar line for whichever candidate source
+		// actually lands on this destination pixel, preferring the nearest
+		// of any that do (real occlusion resolution), instead of a single
+		// forward shift. Ported from Gilleece/moonlight-android-xr's
+		// xr_renderer.c (UPSAMPLE_FRAGMENT_SRC + OFFSET_FRAGMENT_SRC's
+		// occlusion branch), collapsed into one pass since Godot's per-eye
+		// fragment shader here doesn't have a cheap way to share a
+		// pre-pass between the two eye invocations.
+		float parallax = 0.042;
+		ivec2 low_sz = textureSize(depth_texture, 0);
+		float n = float(low_sz.x);
+		float texel = 1.0 / n;
+
+		vec3 hi_color = sample_stream(uv);
+		vec2 lp = uv * n - 0.5;
+		ivec2 base = ivec2(floor(lp));
+
+		// 5x5 joint bilateral tap: weight each low-res depth neighbour by
+		// how closely its guide color matches the real color here, so the
+		// depth edge snaps to the color edge instead of straddling it.
+		float num = 0.0;
+		float den = 0.0;
+		float dlo = 1.0;
+		float dhi = 0.0;
+		for (int dy = -2; dy <= 2; dy++) {
+			for (int dx = -2; dx <= 2; dx++) {
+				ivec2 q = clamp(base + ivec2(dx, dy), ivec2(0), ivec2(int(n) - 1));
+				float s = texelFetch(depth_texture, q, 0).r;
+				vec3 gcol = texelFetch(depth_guide_texture, q, 0).rgb;
+				vec2 off = vec2(q) - lp;
+				float ws = exp(-dot(off, off) / (2.0 * 1.5 * 1.5));
+				vec3 cd = hi_color - gcol;
+				float wr = exp(-dot(cd, cd) / (2.0 * 0.12 * 0.12));
+				float w = ws * wr;
+				num += w * s;
+				den += w;
+				dlo = min(dlo, s);
+				dhi = max(dhi, s);
+			}
+		}
+		float depth_here = num / max(den, 1e-6);
+		float span = dhi - dlo;
+		if (span >= 0.05) {
+			float edge_u = clamp((depth_here - dlo) / max(span, 1e-6), 0.0, 1.0);
+			float snapped = dlo + span / (1.0 + exp(-24.0 * (edge_u - 0.5)));
+			depth_here = mix(depth_here, snapped, 0.6);
+		}
+
+		bool is_left = (int(VIEW_INDEX) == 0);
+		float eye_sign = is_left ? -1.0 : 1.0;
+
+		// Solve e(t) = t + eye_sign * parallax * (depth(uv.x + t) - convergence) = 0
+		// for t: every zero crossing is a source pixel that genuinely lands
+		// on this destination pixel. Search the raw low-res depth (cheap,
+		// matches the reference implementation's design) and keep whichever
+		// crossing has the nearest (largest) depth - the surface that wins
+		// the occlusion.
+		int reach = int(ceil(parallax * n * max(convergence, 1.0 - convergence))) + 2;
+		float best_off = eye_sign * -parallax * (depth_here - convergence);
+		float best_depth = -1.0;
+		ivec2 prev_q = clamp(base + ivec2(-reach, 0), ivec2(0), ivec2(int(n) - 1));
+		float prev_depth = texelFetch(depth_texture, prev_q, 0).r;
+		float prev_t = float(-reach) * texel;
+		float prev_err = prev_t + eye_sign * parallax * (prev_depth - convergence);
+		for (int t = -reach + 1; t <= reach; t++) {
+			ivec2 q = clamp(base + ivec2(t, 0), ivec2(0), ivec2(int(n) - 1));
+			float cur_depth = texelFetch(depth_texture, q, 0).r;
+			float cur_t = float(t) * texel;
+			float cur_err = cur_t + eye_sign * parallax * (cur_depth - convergence);
+			if (prev_err * cur_err <= 0.0 && abs(cur_err - prev_err) > 1e-6) {
+				float f = clamp(-prev_err / (cur_err - prev_err), 0.0, 1.0);
+				float rd = prev_depth + f * (cur_depth - prev_depth);
+				if (rd > best_depth) {
+					best_depth = rd;
+					best_off = mix(prev_t, cur_t, f);
+				}
+			}
+			prev_err = cur_err;
+			prev_depth = cur_depth;
+			prev_t = cur_t;
+		}
+
+		vec2 src_uv = vec2(clamp(uv.x + best_off, 0.0, 1.0), uv.y);
 		ALBEDO = filtered_stream(src_uv);
 	}
 }

--- a/src/shaders/yuv_display.gdshader
+++ b/src/shaders/yuv_display.gdshader
@@ -18,6 +18,13 @@ uniform sampler2D depth_texture : hint_default_white, filter_linear, repeat_disa
 // depth_upsample.gdshader / depth_offset.gdshader for how).
 uniform sampler2D upsampled_depth_texture : hint_default_white, filter_linear;
 uniform sampler2D offset_texture : hint_default_white, filter_linear;
+// The literal 256x256 RGBA color capture depth_viewport.gd feeds to MiDaS
+// (depth_estimator.gd's depth_viewport, same texture depth_upsample.gdshader
+// calls depth_guide_texture) - stereo_mode 9 (MiDaS-DMap-Input) shows this
+// directly, unprocessed, to check whether a fixed/scene-independent artifact
+// seen in DMap is already present in the model's INPUT (a capture/mapping
+// bug) rather than something the model or the upsample pass invented.
+uniform sampler2D depth_guide_texture : hint_default_black, filter_linear;
 // Must match depth_estimator.gd's _pass_parallax exactly - it's baked into
 // offset_texture's encoding via depth_offset.gdshader's own reach
 // computation from the same value, and decoding here needs the identical
@@ -227,6 +234,10 @@ void fragment() {
 		// FRAGMENT_SRC occlusion branch. Both textures are addressed in
 		// tile_uv space (matching how depth_estimator.gd rendered them),
 		// not uv (which already has uv_region's tiling/cropping applied).
+		// The error function's sign here (+disparity, not -) must match
+		// depth_offset.gdshader's own search exactly - verified against
+		// xr_renderer.c directly (see git history 2026-08); refining toward
+		// a root of the WRONG equation is worse than not refining at all.
 		float low_res_width = float(textureSize(upsampled_depth_texture, 0).x);
 		float parallax = mode5_parallax;
 		float disp_texels = parallax * low_res_width;
@@ -243,8 +254,8 @@ void fragment() {
 			float d0 = texture(upsampled_depth_texture, vec2(tc_x, tile_uv.y)).r;
 			float dm = texture(upsampled_depth_texture, vec2(tc_x - h, tile_uv.y)).r;
 			float dp = texture(upsampled_depth_texture, vec2(tc_x + h, tile_uv.y)).r;
-			float e = (tc_x - tile_uv.x) - disparity * (d0 - convergence);
-			float slope = 1.0 - disparity * (dp - dm) / (2.0 * h);
+			float e = (tc_x - tile_uv.x) + disparity * (d0 - convergence);
+			float slope = 1.0 + disparity * (dp - dm) / (2.0 * h);
 			if (abs(slope) < 0.25) {
 				slope = 0.25;
 			}
@@ -268,6 +279,25 @@ void fragment() {
 	if (stereo_mode == 7) {
 		float d = texture(upsampled_depth_texture, tile_uv).r;
 		COLOR = vec4(heatmap(d), 1.0);
+	} else if (stereo_mode == 8) {
+		// MiDaS-DMap-Raw: the RAW pre-upsample depth_texture (the model's
+		// actual 256x256 output, before depth_upsample.gdshader's joint
+		// bilateral filter touches it) - lets us tell apart "the model
+		// itself produced this" from "the upsample/warp pass invented
+		// this", when DMap shows content that doesn't correspond to
+		// anything on the real desktop. Same UV mapping as
+		// upsampled_depth_texture (both cover UV 0..1 = the full cropped
+		// frame 1:1), just coarser since it's the raw 256x256 grid instead
+		// of the quarter-native-res upsample.
+		float d = texture(depth_texture, tile_uv).r;
+		COLOR = vec4(heatmap(d), 1.0);
+	} else if (stereo_mode == 9) {
+		// MiDaS-DMap-Input: the literal color image fed to the model, no
+		// heatmap, no processing at all - if a fixed/scene-independent
+		// artifact is already visible HERE, it's a capture/mapping bug
+		// (depth_viewport/depth_target in depth_estimator.gd), not the
+		// model or either shader pass.
+		COLOR = vec4(texture(depth_guide_texture, tile_uv).rgb, 1.0);
 	} else if (filter_mode > 0 || sharpen > 0.0) {
 		vec3 col = filtered_stream(uv);
 		COLOR = vec4(col, 1.0);

--- a/src/shaders/yuv_display.gdshader
+++ b/src/shaders/yuv_display.gdshader
@@ -32,6 +32,12 @@ uniform sampler2D depth_guide_texture : hint_default_black, filter_linear;
 // (depth_estimator.gd's _setup_warp_passes()/set_parallax()) rather than
 // left at this default, precisely so the two can't drift apart.
 uniform float mode5_parallax = 0.006;
+// stereo_mode 10 (MiDaS-Fast) only - toggled 0/1 every render frame by
+// depth_estimator.gd's process(), so the Newton refinement below runs on
+// alternating frames instead of every frame (amortizing that cost over
+// time rather than cutting it outright, on the theory that one stale/
+// unrefined frame out of every two is imperceptible at 72Hz+).
+uniform int warp_frame_parity = 0;
 uniform float convergence = 0.5;
 uniform float balance_shift = 0.5;
 
@@ -224,13 +230,13 @@ void fragment() {
 
 		uv = vec2(clamp(uv.x - shift * eye_sign, 0.0, 1.0), uv.y);
 	}
-	else if (stereo_mode == 5 || stereo_mode == 6) {
+	else if (stereo_mode == 5 || stereo_mode == 6 || stereo_mode == 10) {
 		// MiDaS-GPU path's gather: cheap by design, since depth_estimator.gd
 		// already ran the expensive edge-aware upsample + occlusion search
 		// ONCE per frame (not per eye) into upsampled_depth_texture /
 		// offset_texture - see depth_upsample.gdshader / depth_offset.gdshader.
-		// This just decodes the offset-search's result and does two Newton
-		// steps for sub-texel accuracy, mirroring xr_renderer.c's
+		// This just decodes the offset-search's result and does up to two
+		// Newton steps for sub-texel accuracy, mirroring xr_renderer.c's
 		// FRAGMENT_SRC occlusion branch. Both textures are addressed in
 		// tile_uv space (matching how depth_estimator.gd rendered them),
 		// not uv (which already has uv_region's tiling/cropping applied).
@@ -238,6 +244,14 @@ void fragment() {
 		// depth_offset.gdshader's own search exactly - verified against
 		// xr_renderer.c directly (see git history 2026-08); refining toward
 		// a root of the WRONG equation is worse than not refining at all.
+		//
+		// MiDaS-Fast (stereo_mode 10) is a GPU-cost experiment (2026-08-18):
+		// it also drives depth_estimator.gd to run the pre-pass above at
+		// EX_PASS_DIVISOR (a quarter the pixels of stereo_mode 6's) and
+		// throttled to warp_update_interval instead of every render frame,
+		// AND does only 1 Newton step here instead of 2 - see
+		// warp_update_interval's comment in depth_estimator.gd for why.
+		// stereo_mode 6 (MiDaS-Std) is untouched by any of this.
 		float low_res_width = float(textureSize(upsampled_depth_texture, 0).x);
 		float parallax = mode5_parallax;
 		float disp_texels = parallax * low_res_width;
@@ -250,7 +264,14 @@ void fragment() {
 
 		float disparity = is_left ? parallax : -parallax;
 		float h = 1.0 / low_res_width;
+		int newton_steps = 2;
+		if (stereo_mode == 10) {
+			newton_steps = (warp_frame_parity == 0) ? 1 : 0;
+		}
 		for (int i = 0; i < 2; i++) {
+			if (i >= newton_steps) {
+				break;
+			}
 			float d0 = texture(upsampled_depth_texture, vec2(tc_x, tile_uv.y)).r;
 			float dm = texture(upsampled_depth_texture, vec2(tc_x - h, tile_uv.y)).r;
 			float dp = texture(upsampled_depth_texture, vec2(tc_x + h, tile_uv.y)).r;

--- a/src/shaders/yuv_display.gdshader
+++ b/src/shaders/yuv_display.gdshader
@@ -13,6 +13,18 @@ uniform float blur_scale = 1.0;
 uniform int stereo_mode = 0;
 uniform int eye_index = 0;
 uniform sampler2D depth_texture : hint_default_white, filter_linear, repeat_disable;
+// stereo_mode 5's pre-computed textures (depth_estimator.gd owns the passes
+// that produce these, once per frame, shared by both eyes - see
+// depth_upsample.gdshader / depth_offset.gdshader for how).
+uniform sampler2D upsampled_depth_texture : hint_default_white, filter_linear;
+uniform sampler2D offset_texture : hint_default_white, filter_linear;
+// Must match depth_estimator.gd's _pass_parallax exactly - it's baked into
+// offset_texture's encoding via depth_offset.gdshader's own reach
+// computation from the same value, and decoding here needs the identical
+// reach or the disparity comes out scaled wrong. Set from GDScript
+// (depth_estimator.gd's _setup_warp_passes()/set_parallax()) rather than
+// left at this default, precisely so the two can't drift apart.
+uniform float mode5_parallax = 0.006;
 uniform float convergence = 0.5;
 uniform float balance_shift = 0.5;
 
@@ -86,6 +98,27 @@ vec2 clamp_to_region(vec2 f) {
 	return clamp(f, uv_region.xy + guard, uv_region.xy + uv_region.zw - guard);
 }
 
+// Classic 5-stop jet-style heatmap (blue -> cyan -> green -> yellow -> red)
+// for visualizing a scalar depth value - far more legible than grayscale for
+// spotting subtle variation, which is the whole point of stereo_mode 7.
+vec3 heatmap(float t) {
+	t = clamp(t, 0.0, 1.0);
+	vec3 c1 = vec3(0.0, 0.0, 1.0);
+	vec3 c2 = vec3(0.0, 1.0, 1.0);
+	vec3 c3 = vec3(0.0, 1.0, 0.0);
+	vec3 c4 = vec3(1.0, 1.0, 0.0);
+	vec3 c5 = vec3(1.0, 0.0, 0.0);
+	if (t < 0.25) {
+		return mix(c1, c2, t / 0.25);
+	} else if (t < 0.5) {
+		return mix(c2, c3, (t - 0.25) / 0.25);
+	} else if (t < 0.75) {
+		return mix(c3, c4, (t - 0.5) / 0.25);
+	} else {
+		return mix(c4, c5, (t - 0.75) / 0.25);
+	}
+}
+
 vec3 sample_stream(vec2 uv) {
 	uv = clamp_to_region(uv);
 	if (yuv_mode > 0) {
@@ -144,7 +177,7 @@ void fragment() {
 
 	vec2 uv = to_frame_uv(tile_uv);
 
-	if (stereo_mode >= 3) {
+	if (stereo_mode == 3 || stereo_mode == 4) {
 		vec2 depth_texel = 1.0 / vec2(textureSize(depth_texture, 0));
 		float parallax = 0.042;
 		float half_parallax = parallax * 0.5;
@@ -184,8 +217,58 @@ void fragment() {
 
 		uv = vec2(clamp(uv.x - shift * eye_sign, 0.0, 1.0), uv.y);
 	}
+	else if (stereo_mode == 5 || stereo_mode == 6) {
+		// MiDaS-GPU path's gather: cheap by design, since depth_estimator.gd
+		// already ran the expensive edge-aware upsample + occlusion search
+		// ONCE per frame (not per eye) into upsampled_depth_texture /
+		// offset_texture - see depth_upsample.gdshader / depth_offset.gdshader.
+		// This just decodes the offset-search's result and does two Newton
+		// steps for sub-texel accuracy, mirroring xr_renderer.c's
+		// FRAGMENT_SRC occlusion branch. Both textures are addressed in
+		// tile_uv space (matching how depth_estimator.gd rendered them),
+		// not uv (which already has uv_region's tiling/cropping applied).
+		float low_res_width = float(textureSize(upsampled_depth_texture, 0).x);
+		float parallax = mode5_parallax;
+		float disp_texels = parallax * low_res_width;
+		int reach = int(ceil(abs(disp_texels) * max(convergence, 1.0 - convergence))) + 2;
 
-	if (filter_mode > 0 || sharpen > 0.0) {
+		vec2 enc = texture(offset_texture, tile_uv).rg;
+		bool is_left = (eye_index == 1);
+		float eye_off = (is_left ? enc.r : enc.g) - 0.5;
+		float tc_x = tile_uv.x + eye_off * 2.0 * float(reach) / low_res_width;
+
+		float disparity = is_left ? parallax : -parallax;
+		float h = 1.0 / low_res_width;
+		for (int i = 0; i < 2; i++) {
+			float d0 = texture(upsampled_depth_texture, vec2(tc_x, tile_uv.y)).r;
+			float dm = texture(upsampled_depth_texture, vec2(tc_x - h, tile_uv.y)).r;
+			float dp = texture(upsampled_depth_texture, vec2(tc_x + h, tile_uv.y)).r;
+			float e = (tc_x - tile_uv.x) - disparity * (d0 - convergence);
+			float slope = 1.0 - disparity * (dp - dm) / (2.0 * h);
+			if (abs(slope) < 0.25) {
+				slope = 0.25;
+			}
+			tc_x -= clamp(e / slope, -4.0 * h, 4.0 * h);
+		}
+
+		uv = to_frame_uv(vec2(clamp(tc_x, 0.0, 1.0), tile_uv.y));
+	}
+
+	// MiDaS-DMap: shows upsampled_depth_texture - the actual post-upsample
+	// data stereo_mode 5/6's real warp consumes (depth_estimator.gd's
+	// depth_upsample.gdshader pass), not the raw pre-upsample depth_texture -
+	// as a heatmap instead of the video, mono (no warp/disparity). This is
+	// what the warp is actually working with, so it's the right thing to
+	// stare at when asking "is the depth data itself the problem". Same
+	// tile_uv addressing as the mode 5/6 branch above uses for the same
+	// texture. Separate if/else from the stereo_mode chain above (not
+	// chained onto it with else-if) because that chain only adjusts uv -
+	// modes 1-6 still need to fall through to the normal color-sampling
+	// block below, which this must skip instead.
+	if (stereo_mode == 7) {
+		float d = texture(upsampled_depth_texture, tile_uv).r;
+		COLOR = vec4(heatmap(d), 1.0);
+	} else if (filter_mode > 0 || sharpen > 0.0) {
 		vec3 col = filtered_stream(uv);
 		COLOR = vec4(col, 1.0);
 	} else if (yuv_mode > 0) {

--- a/src/shaders/yuv_display.gdshader
+++ b/src/shaders/yuv_display.gdshader
@@ -32,12 +32,14 @@ uniform sampler2D depth_guide_texture : hint_default_black, filter_linear;
 // (depth_estimator.gd's _setup_warp_passes()/set_parallax()) rather than
 // left at this default, precisely so the two can't drift apart.
 uniform float mode5_parallax = 0.006;
-// stereo_mode 10 (MiDaS-Fast) only - toggled 0/1 every render frame by
-// depth_estimator.gd's process(), so the Newton refinement below runs on
-// alternating frames instead of every frame (amortizing that cost over
-// time rather than cutting it outright, on the theory that one stale/
-// unrefined frame out of every two is imperceptible at 72Hz+).
-uniform int warp_frame_parity = 0;
+// How many Newton refinement steps the gather below does THIS frame (see
+// it in use further down) - computed and pushed every render frame by
+// depth_estimator.gd's process()/set_enabled() based on the active warp
+// tier (MiDaS-Std always pushes 2; MiDaS-Fast/-Fastest cycle 1-then-0s on
+// a period, amortizing the refinement's cost across frames instead of
+// paying it every frame). The shader just reads whatever's here - it
+// doesn't know or care which tier is active.
+uniform int warp_newton_steps = 2;
 uniform float convergence = 0.5;
 uniform float balance_shift = 0.5;
 
@@ -230,7 +232,7 @@ void fragment() {
 
 		uv = vec2(clamp(uv.x - shift * eye_sign, 0.0, 1.0), uv.y);
 	}
-	else if (stereo_mode == 5 || stereo_mode == 6 || stereo_mode == 10) {
+	else if (stereo_mode == 5 || stereo_mode == 6 || stereo_mode == 10 || stereo_mode == 11) {
 		// MiDaS-GPU path's gather: cheap by design, since depth_estimator.gd
 		// already ran the expensive edge-aware upsample + occlusion search
 		// ONCE per frame (not per eye) into upsampled_depth_texture /
@@ -245,11 +247,10 @@ void fragment() {
 		// xr_renderer.c directly (see git history 2026-08); refining toward
 		// a root of the WRONG equation is worse than not refining at all.
 		//
-		// MiDaS-Fast (stereo_mode 10) is a GPU-cost experiment (2026-08-18):
-		// it also drives depth_estimator.gd to run the pre-pass above at
-		// EX_PASS_DIVISOR (a quarter the pixels of stereo_mode 6's) and
-		// throttled to warp_update_interval instead of every render frame,
-		// AND does only 1 Newton step here instead of 2 - see
+		// MiDaS-Fast/-Fastest (stereo_mode 10/11) are a GPU-cost experiment
+		// (2026-08-18): they also drive depth_estimator.gd to run the
+		// pre-pass above at a smaller divisor and throttled to
+		// warp_update_interval instead of every render frame - see
 		// warp_update_interval's comment in depth_estimator.gd for why.
 		// stereo_mode 6 (MiDaS-Std) is untouched by any of this.
 		float low_res_width = float(textureSize(upsampled_depth_texture, 0).x);
@@ -264,12 +265,8 @@ void fragment() {
 
 		float disparity = is_left ? parallax : -parallax;
 		float h = 1.0 / low_res_width;
-		int newton_steps = 2;
-		if (stereo_mode == 10) {
-			newton_steps = (warp_frame_parity == 0) ? 1 : 0;
-		}
 		for (int i = 0; i < 2; i++) {
-			if (i >= newton_steps) {
+			if (i >= warp_newton_steps) {
 				break;
 			}
 			float d0 = texture(upsampled_depth_texture, vec2(tc_x, tile_uv.y)).r;

--- a/src/state_manager.gd
+++ b/src/state_manager.gd
@@ -80,7 +80,7 @@ func load_host_state(ip: String):
 	main.double_h = save.get_value(ip, "double_h", false)
 	if save.has_section_key(ip, "sbs_mode"):
 		main.sbs_mode = clampi(save.get_value(ip, "sbs_mode", 0), 0, 2)
-		main.ai_3d_mode = clampi(save.get_value(ip, "ai_3d_mode", 0), 0, 4)
+		main.ai_3d_mode = clampi(save.get_value(ip, "ai_3d_mode", 0), 0, 6)
 	elif save.has_section_key(ip, "stereo_mode"):
 		var old = clampi(save.get_value(ip, "stereo_mode", 0), 0, 4)
 		if old <= 2:

--- a/src/state_manager.gd
+++ b/src/state_manager.gd
@@ -80,7 +80,7 @@ func load_host_state(ip: String):
 	main.double_h = save.get_value(ip, "double_h", false)
 	if save.has_section_key(ip, "sbs_mode"):
 		main.sbs_mode = clampi(save.get_value(ip, "sbs_mode", 0), 0, 2)
-		main.ai_3d_mode = clampi(save.get_value(ip, "ai_3d_mode", 0), 0, 1)
+		main.ai_3d_mode = clampi(save.get_value(ip, "ai_3d_mode", 0), 0, 4)
 	elif save.has_section_key(ip, "stereo_mode"):
 		var old = clampi(save.get_value(ip, "stereo_mode", 0), 0, 4)
 		if old <= 2:

--- a/src/state_manager.gd
+++ b/src/state_manager.gd
@@ -42,7 +42,9 @@ func save_host_state():
 	save.set_value(ip, "is_polaris_host", main.is_polaris_host)
 	save.set_value(ip, "resolution_idx", main.resolution_idx)
 	save.set_value(ip, "sbs_mode", main.sbs_mode)
-	save.set_value(ip, "ai_3d_mode", main.ai_3d_mode)
+	save.set_value(ip, "ai_3d_model", main.ai_3d_model)
+	save.set_value(ip, "ai_3d_quality", main.ai_3d_quality)
+	save.set_value(ip, "ai_3d_debug", main.ai_3d_debug)
 	save.set_value(ip, "bitrate_idx", main.bitrate_idx)
 	save.set_value(ip, "double_h", main.double_h)
 	save.set_value(ip, "screen_layout", JSON.stringify(main.layout.to_dict()))
@@ -80,19 +82,37 @@ func load_host_state(ip: String):
 	main.double_h = save.get_value(ip, "double_h", false)
 	if save.has_section_key(ip, "sbs_mode"):
 		main.sbs_mode = clampi(save.get_value(ip, "sbs_mode", 0), 0, 2)
-		main.ai_3d_mode = clampi(save.get_value(ip, "ai_3d_mode", 0), 0, 6)
+		if save.has_section_key(ip, "ai_3d_model"):
+			main.ai_3d_model = clampi(save.get_value(ip, "ai_3d_model", 0), 0, 1)
+			main.ai_3d_quality = clampi(save.get_value(ip, "ai_3d_quality", 0), 0, 3)
+			main.ai_3d_debug = clampi(save.get_value(ip, "ai_3d_debug", 0), 0, 3)
+		elif save.has_section_key(ip, "ai_3d_mode"):
+			# Migrate the old flat 0-6 "3D AI" cycle (2026-08-18 split into
+			# three independent controls: model/quality/debug) - 0=Off,
+			# 1=Fast, 2=Standard, 3=Fastest, 4-6=DMap/-Raw/-Input debug
+			# views (always at Standard quality, since the old scheme had
+			# no independent quality selection for them).
+			var old = clampi(save.get_value(ip, "ai_3d_mode", 0), 0, 6)
+			main.ai_3d_model = 0 if old == 0 else 1
+			main.ai_3d_debug = 0 if old < 4 else old - 3
+			match old:
+				1: main.ai_3d_quality = 2 # Fast
+				3: main.ai_3d_quality = 1 # Fastest
+				_: main.ai_3d_quality = 3 # Standard (old modes 0, 2, 4-6)
 	elif save.has_section_key(ip, "stereo_mode"):
 		var old = clampi(save.get_value(ip, "stereo_mode", 0), 0, 4)
 		if old <= 2:
 			main.sbs_mode = old
-			main.ai_3d_mode = 0
+			main.ai_3d_model = 0
 		else:
 			main.sbs_mode = 0
-			main.ai_3d_mode = 1
+			main.ai_3d_model = 1
 	if main.screen_mesh.material_override is ShaderMaterial:
 		main.screen_mesh.material_override.set_shader_parameter("stereo_mode", main.settings_controller.get_stereo_mode())
 	main.ui_controller.update_option_btn(main._ui_sbs_btn, main.settings_controller.sbs_labels[main.sbs_mode])
-	main.ui_controller.update_option_btn(main._ui_3d_btn, main.settings_controller.ai_3d_labels[main.ai_3d_mode])
+	main.ui_controller.update_option_btn(main._ui_3d_btn, main.settings_controller.ai_3d_model_labels[main.ai_3d_model])
+	main.ui_controller.update_option_btn(main._ui_3d_quality_btn, main.settings_controller.ai_3d_quality_labels[main.ai_3d_quality])
+	main.ui_controller.update_option_btn(main._ui_3d_debug_btn, main.settings_controller.ai_3d_debug_labels[main.ai_3d_debug])
 	main.ui_controller.update_3d_btn_state()
 	main.ui_controller.update_option_btn(main._ui_fps_btn, "%d" % main.stream_fps)
 	main.host_resolution = main.compute_requested_resolution()

--- a/src/state_manager.gd
+++ b/src/state_manager.gd
@@ -80,7 +80,7 @@ func load_host_state(ip: String):
 	main.double_h = save.get_value(ip, "double_h", false)
 	if save.has_section_key(ip, "sbs_mode"):
 		main.sbs_mode = clampi(save.get_value(ip, "sbs_mode", 0), 0, 2)
-		main.ai_3d_mode = clampi(save.get_value(ip, "ai_3d_mode", 0), 0, 6)
+		main.ai_3d_mode = clampi(save.get_value(ip, "ai_3d_mode", 0), 0, 5)
 	elif save.has_section_key(ip, "stereo_mode"):
 		var old = clampi(save.get_value(ip, "stereo_mode", 0), 0, 4)
 		if old <= 2:

--- a/src/state_manager.gd
+++ b/src/state_manager.gd
@@ -80,7 +80,7 @@ func load_host_state(ip: String):
 	main.double_h = save.get_value(ip, "double_h", false)
 	if save.has_section_key(ip, "sbs_mode"):
 		main.sbs_mode = clampi(save.get_value(ip, "sbs_mode", 0), 0, 2)
-		main.ai_3d_mode = clampi(save.get_value(ip, "ai_3d_mode", 0), 0, 5)
+		main.ai_3d_mode = clampi(save.get_value(ip, "ai_3d_mode", 0), 0, 6)
 	elif save.has_section_key(ip, "stereo_mode"):
 		var old = clampi(save.get_value(ip, "stereo_mode", 0), 0, 4)
 		if old <= 2:

--- a/src/stream_manager.gd
+++ b/src/stream_manager.gd
@@ -62,7 +62,18 @@ func start_stream(host_id: int, app_id: int, forced_resolution: Vector2i = Vecto
 	if main.bitrate_idx >= 0:
 		bitrate = main.bitrates[main.bitrate_idx] * 1000
 	else:
-		bitrate = _auto_bitrate(w, h)
+		# Auto bitrate picks its tier from the UNCAPPED resolution, not w/h
+		# above - w/h can be reduced by the MiDaS-Fast/-Fastest resolution
+		# cap (main.gd's MIDAS_FAST_MAX_PIXELS), which is meant to trade pixels
+		# for FPS, not ALSO cut the bitrate. _auto_bitrate() keying off the
+		# capped w/h used to do both at once (confirmed via logs: capping to
+		# 3712x2088 or 2560x1440 both dropped bitrate from 80000 to 40000),
+		# which starved the video of real detail and degraded MiDaS-Fast/
+		# -Fastest's depth quality well beyond what the resolution cut alone
+		# would explain (see compute_requested_resolution()'s apply_midas_cap
+		# param). Same bitrate at fewer pixels means MORE bits per pixel.
+		var bitrate_ref = main.compute_requested_resolution(false)
+		bitrate = _auto_bitrate(bitrate_ref.x, bitrate_ref.y)
 	resize_stream_viewport(w, h)
 	var options = {}
 	if local_capture_mode:
@@ -258,20 +269,23 @@ func _on_v2_launch_response(response: Dictionary):
 	_b().start_stream_v2(ip, server_info, stream_config, false)
 	main._log("[STREAM] start_stream called (%dx%d@%d %dMbps)" % [w, h, fps, br])
 
+# Scales linearly against a fixed reference ratio (3840x2160 @ 80000 kbps)
+# instead of the old fixed pixel-count buckets - so it also scales correctly
+# ABOVE 4K (a future multi-monitor layout's total pixel count can exceed a
+# single 4K screen's) and smoothly below it (1080p, 720p, etc.), rather than
+# jumping between a handful of fixed tiers with cliffs at each boundary (a
+# cliff like this is what caused MiDaS-Fast/-Fastest's resolution cap to
+# ALSO cut bitrate in half, see compute_requested_resolution()'s
+# apply_midas_cap param). main.bitrate_idx >= 0 (the manual override) never
+# calls this at all - see start_stream()'s own check.
+const AUTO_BITRATE_REF_PIXELS := 3840 * 2160
+const AUTO_BITRATE_REF_KBPS := 80000
+const AUTO_BITRATE_MIN_KBPS := 1000
+
 func _auto_bitrate(w: int, h: int) -> int:
 	var pixels = w * h
-	if pixels >= 3840 * 2160:
-		return 80000
-	elif pixels >= 2560 * 1440:
-		return 40000
-	elif pixels >= 3440 * 1440:
-		return 50000
-	elif pixels >= 1920 * 1080:
-		return 20000
-	elif pixels >= 1600 * 1200:
-		return 20000
-	else:
-		return 10000
+	var kbps = int(AUTO_BITRATE_REF_KBPS * float(pixels) / float(AUTO_BITRATE_REF_PIXELS))
+	return maxi(kbps, AUTO_BITRATE_MIN_KBPS)
 
 func resize_stream_viewport(w: int, h: int):
 	main.stream_viewport.size = Vector2i(w, h)

--- a/src/ui_controller.gd
+++ b/src/ui_controller.gd
@@ -507,6 +507,14 @@ func build_ui():
 	_tab_btn_monitors.custom_minimum_size = Vector2(160, 44)
 	_tab_btn_monitors.add_theme_font_size_override("font_size", 22)
 	_tab_btn_monitors.add_theme_color_override("font_color", Color(1, 1, 1, 0.5))
+	# Disabled (2026-08-18), not removed - the underlying multi-monitor code
+	# (composition_layer_manager.gd, vr_screen.gd, screen_layout.gd etc.) is
+	# still fully wired up and depended on by AI-3D itself, this just hides
+	# the tab/button so the feature isn't user-facing yet. switch_tab(3) is
+	# ONLY ever reached via this button's own click handler below (no other
+	# call site), so hiding it fully disables reachability. Set .visible =
+	# true again to bring the tab back.
+	_tab_btn_monitors.visible = false
 	tab_bar.add_child(_tab_btn_monitors)
 
 	var tab_margin = Control.new()

--- a/src/ui_controller.gd
+++ b/src/ui_controller.gd
@@ -49,20 +49,44 @@ func on_sbs_toggled():
 
 func on_ai_3d_toggled():
 	main.auto_detect_enabled = false
-	main.settings_controller.cycle_ai_3d_mode()
+	main.settings_controller.cycle_ai_3d_model()
+
+func on_ai_3d_quality_toggled():
+	main.auto_detect_enabled = false
+	main.settings_controller.cycle_ai_3d_quality()
+
+func on_ai_3d_debug_toggled():
+	main.auto_detect_enabled = false
+	main.settings_controller.cycle_ai_3d_debug()
 
 func update_stereo_shader():
 	if main.screen_mesh.material_override is ShaderMaterial:
 		main.screen_mesh.material_override.set_shader_parameter("stereo_mode", main.settings_controller.get_stereo_mode())
 	update_option_btn(main._ui_sbs_btn, main.settings_controller.sbs_labels[main.sbs_mode])
-	update_option_btn(main._ui_3d_btn, main.settings_controller.ai_3d_labels[main.ai_3d_mode])
+	update_option_btn(main._ui_3d_btn, main.settings_controller.ai_3d_model_labels[main.ai_3d_model])
+	update_option_btn(main._ui_3d_quality_btn, main.settings_controller.ai_3d_quality_labels[main.ai_3d_quality])
+	update_option_btn(main._ui_3d_debug_btn, main.settings_controller.ai_3d_debug_labels[main.ai_3d_debug])
 	update_3d_btn_state()
 
 func update_3d_btn_state():
+	var disabled = main.sbs_mode > 0 or main.screens.size() > 1
 	if main._ui_3d_btn:
-		var disabled = main.sbs_mode > 0 or main.screens.size() > 1
 		main._ui_3d_btn.disabled = disabled
 		main._ui_3d_btn.modulate.a = 0.3 if disabled else 1.0
+	# Quality/debug controls are additionally meaningless (and disabled)
+	# whenever AI-3D itself is off - no point picking a tier or a debug
+	# view for a model that isn't running.
+	var sub_disabled = disabled or main.ai_3d_model == 0
+	if main._ui_3d_quality_btn:
+		main._ui_3d_quality_btn.disabled = sub_disabled
+		main._ui_3d_quality_btn.modulate.a = 0.3 if sub_disabled else 1.0
+	# Debug is disabled unconditionally (2026-08-18, matches
+	# settings_controller.gd's cycle_ai_3d_debug() early return) - not
+	# folded into sub_disabled above since that's meant to reflect "would
+	# be usable if AI-3D were on," and this one's just off regardless.
+	if main._ui_3d_debug_btn:
+		main._ui_3d_debug_btn.disabled = true
+		main._ui_3d_debug_btn.modulate.a = 0.3
 
 func update_monitor_tab():
 	if not main._ui_apply_preset_btn:
@@ -509,8 +533,17 @@ func build_ui():
 	disp_row1.add_child(main._ui_pt_btn)
 	main._ui_sbs_btn = make_option_btn("SBS", "Off")
 	disp_row1.add_child(main._ui_sbs_btn)
-	main._ui_3d_btn = make_option_btn("3D AI", "2D")
+	main._ui_3d_btn = make_option_btn("3D AI", "Off")
 	disp_row1.add_child(main._ui_3d_btn)
+	main._ui_3d_quality_btn = make_option_btn("3D Quality", "Auto")
+	disp_row1.add_child(main._ui_3d_quality_btn)
+	# Debug is disabled (and dim) whenever 3D AI is off, which is most of
+	# the time - deliberately left on the same row as everything else even
+	# though 5 buttons overlaps/runs off the panel at this width, per
+	# explicit instruction (2026-08-18): fine since it's rarely the visible/
+	# active one.
+	main._ui_3d_debug_btn = make_option_btn("3D Debug", "Off")
+	disp_row1.add_child(main._ui_3d_debug_btn)
 
 	var disp_gap1 = Control.new()
 	disp_gap1.custom_minimum_size = Vector2(0, 20)
@@ -764,6 +797,8 @@ func build_ui():
 	main._ui_hand_tracking_btn.button_down.connect(func(): main.settings_controller.toggle_hand_tracking())
 	main._ui_sbs_btn.button_down.connect(func(): on_sbs_toggled())
 	main._ui_3d_btn.button_down.connect(func(): on_ai_3d_toggled())
+	main._ui_3d_quality_btn.button_down.connect(func(): on_ai_3d_quality_toggled())
+	main._ui_3d_debug_btn.button_down.connect(func(): on_ai_3d_debug_toggled())
 	main._ui_monitors_btn.button_down.connect(func(): _cycle_monitors_btn())
 	main._ui_virtual_monitors_btn.button_down.connect(func(): _cycle_virtual_btn())
 	main._ui_apply_preset_btn.button_down.connect(func(): _on_apply_preset_pressed())


### PR DESCRIPTION
## Summary
- Adds MiDaS TFLite depth estimation with an occlusion-aware, joint-bilateral-upsampled stereo warp (ported from Gilleece/moonlight-android-xr's xr_renderer.c), replacing the earlier single-sample-shift warp.
- Fixes a real quantization bug in the w8a8 MiDaS model's input/output handling that was silently producing garbage depth data (confirmed via direct `.tflite` model inspection).
- Adds two lower-cost quality tiers (MiDaS-Fast, MiDaS-Fastest) alongside the full-quality MiDaS-Std, each trading pre-pass resolution / Newton-refinement cadence for framerate.
- Adds a resolution cap (by total pixel budget, not width/height, so it's aspect-ratio-correct on multi-monitor composites) for MiDaS-Fast/-Fastest, plus a matching fix to Auto bitrate scaling so the cap doesn't also starve bitrate.
- Fixes a stereo-mode-reset bug where AI-3D/SBS silently reset to 2D on every stream (re)start.
- Splits the single "3D AI" toggle into three independent controls: **3D AI** (Off/MiDaS), **3D Quality** (Auto/Fastest/Fast/Standard - Auto picks a tier from resolution + passthrough state), and **3D Debug** (DMap/-Raw/-Input views, currently disabled but wired up).
- Extends the mesh-rendering fallback shader (used when composition layers aren't available) to cover the new quality tiers and debug views, which it was previously missing.
- Hides the Monitors tab in the settings UI - the underlying multi-monitor code stays fully wired up (this PR's AI-3D work depends on it), but the feature itself isn't user-facing yet. One line to bring it back (see ui_controller.gd).

## Test plan
- [ ] Cycle 3D AI Off -> MiDaS, confirm depth/stereo effect applies
- [ ] Cycle 3D Quality through Fastest/Fast/Standard, confirm visible quality difference and FPS improves at lower tiers
- [ ] Toggle Auto quality with passthrough on/off at a few resolutions, confirm it follows the documented table
- [ ] Restart the stream (change resolution/codec) while AI-3D is on, confirm the 3D effect survives the restart
- [ ] Confirm MiDaS-Fast/-Fastest's resolution cap doesn't crash/restart-loop on a non-16:9 multi-monitor layout
