### PR TITLE
Fix 21:9/4:3 sources displayed with wrong aspect ratio

### DIFF
--- a/main.gd
+++ b/main.gd
@@ -190,8 +190,13 @@ var is_polaris_host: bool = false
 # under all of those caps on its own (largest is 3840x2160), so there's
 # nothing to filter for the single-screen case this picker is used for.
 var resolution_idx: int = 1
-var resolutions: Array = [Vector2i(1280, 720), Vector2i(1920, 1080), Vector2i(2560, 1440), Vector2i(3840, 2160), Vector2i(1600, 1200), Vector2i(3440, 1440)]
-var resolution_labels: Array = ["720", "HD", "2K", "4K", "4:3", "21:9"]
+var resolutions: Array = [Vector2i(1280, 720), Vector2i(1920, 1080), Vector2i(2560, 1440), Vector2i(3840, 2160), Vector2i(1600, 1200), Vector2i(2560, 1080), Vector2i(3440, 1440)]
+# 21:9 split into two tiers (2026-08-20, GitHub issue #17) - was a single
+# 3440x1440 entry, which meant there was no way to request a 21:9 source at a
+# more modest pixel budget (matching the HD/2K split every other aspect
+# already gets). 2560x1080 (UWFHD, 64:27) and 3440x1440 (UWQHD, 43:18) are
+# the two real, common ultrawide monitor resolutions - not arbitrary picks.
+var resolution_labels: Array = ["720", "HD", "2K", "4K", "4:3", "21:9 HD", "21:9 2K"]
 var double_h: bool = false
 var bitrate_idx: int = -1
 var bitrates: Array = [5, 10, 15, 20, 30, 40, 50, 60, 80, 100, 120]

--- a/src/depth_estimator.gd
+++ b/src/depth_estimator.gd
@@ -213,9 +213,23 @@ func _setup_warp_passes():
 
 	_resize_warp_passes()
 
-# Sized off native_resolution (the stream's real resolution) rather than a
-# fixed constant, so the passes track resolution changes/restarts. Cheap to
-# call every frame - it's a no-op once the size matches.
+# Sized off the REAL decoded stream resolution (2026-08-20, was
+# main.native_resolution) rather than a fixed constant, so the passes track
+# resolution changes/restarts. Cheap to call every frame - it's a no-op once
+# the size matches. main.native_resolution is ONLY ever updated from a real
+# host manifest (Polaris hosts) - Sunshine/GameStream hosts never send one,
+# so for them it just stays at whatever stale value was last loaded from
+# saved state (a previous host/session), completely disconnected from
+# whatever resolution is actually being requested/decoded right now. This
+# was the root cause of a real on-device bug (garbled horizontal band with
+# AI-3D on, 21:9 2K specifically): the warp gather's own internal working
+# resolution (target below) silently mismatched the real content's aspect,
+# throwing off the offset-search math in depth_offset.gdshader/
+# yuv_display.gdshader's Newton refinement. main.stream_viewport.size is
+# always current (set directly from the video backend's real reported
+# dimensions in stream_manager.gd's resize_stream_viewport()) regardless of
+# host type - the same fix pattern as screen_manager.gd's
+# resize_screen_to_aspect() (GitHub issue #17).
 func _resize_warp_passes():
 	# upsample_mat decodes YUV directly (see depth_upsample.gdshader) and
 	# needs the same uv_region the primary screen's own materials use, so
@@ -226,7 +240,10 @@ func _resize_warp_passes():
 	if upsample_mat and main.primary_screen:
 		upsample_mat.set_shader_parameter("uv_region", main.primary_screen.uv_region)
 
-	var src = main.native_resolution
+	if not main.primary_screen or not main.stream_viewport:
+		return
+	var uv = main.primary_screen.uv_region
+	var src = Vector2i(int(float(main.stream_viewport.size.x) * uv.z), int(float(main.stream_viewport.size.y) * uv.w))
 	if src.x <= 0 or src.y <= 0:
 		return
 	var target = Vector2i(maxi(src.x / _pass_divisor, PASS_MIN_SIZE), maxi(src.y / _pass_divisor, PASS_MIN_SIZE))

--- a/src/screen_manager.gd
+++ b/src/screen_manager.gd
@@ -34,12 +34,33 @@ func toggle_bezel():
 	main.comp.update_bezel()
 	main.state_manager.save_state()
 
+# GitHub issue #17 (2026-08-20): used to prefer s.monitor.frame_rect.size
+# over the real stream_w/stream_h whenever a monitor spec existed - correct
+# for genuine multi-monitor manifests (Polaris hosts report each monitor's
+# real per-output resolution there), but WRONG for any single-screen/non-
+# manifest host (Sunshine et al.): s.monitor there is just whatever the
+# welcome screen's fixed 16:9 placeholder last set, never updated again, so
+# the mesh stayed 16:9 forever regardless of the actual stream's real aspect
+# (a 21:9 source got squeezed into a 16:9-shaped quad). A shader-side
+# letterbox/pillarbox fix was tried first and worked, but the better fix is
+# this: always resize the mesh itself to the REAL decoded content's aspect -
+# resize_to_aspect() below already keeps WIDTH anchored to mesh_size.x (i.e.
+# whatever this screen's current grid-cell footprint width already is) and
+# only adjusts height, so a 21:9 screen ends up shorter (fits the same grid
+# column, less vertical space) and a 4:3 screen taller - the actual visible
+# mesh shape now matches reality instead of hiding the mismatch behind black
+# bars. s.uv_region encodes what fraction of the (possibly multi-monitor
+# composite) stream_w/stream_h this particular screen shows - use just its
+# own slice, not the whole composite, or a genuine future multi-monitor
+# layout would misjudge every screen's fit against the WRONG total. Height
+# growing past a single grid row (e.g. a 4:3 source) can currently overlap a
+# vertical neighbor - a real but deliberately deferred gap, not something
+# this fix attempts to solve yet (see MULTI_MONITOR grid work).
 func resize_screen_to_aspect(stream_w: int, stream_h: int):
 	for s in main.screens:
-		if s.monitor and s.monitor.frame_rect.size.y > 0:
-			s.resize_to_aspect(s.monitor.frame_rect.size.x, s.monitor.frame_rect.size.y)
-		else:
-			s.resize_to_aspect(stream_w, stream_h)
+		var content_w = int(float(stream_w) * s.uv_region.z)
+		var content_h = int(float(stream_h) * s.uv_region.w)
+		s.resize_to_aspect(content_w, content_h)
 	if main.comp_layer and main.comp_layer is OpenXRCompositionLayerQuad:
 		main.comp_layer.set_quad_size(main._mesh_size)
 

--- a/src/ui_controller.gd
+++ b/src/ui_controller.gd
@@ -80,13 +80,16 @@ func update_3d_btn_state():
 	if main._ui_3d_quality_btn:
 		main._ui_3d_quality_btn.disabled = sub_disabled
 		main._ui_3d_quality_btn.modulate.a = 0.3 if sub_disabled else 1.0
-	# Re-enabled (2026-08-19) for on-device DMap inspection while comparing
-	# depth models - visible/interactive again, same disabled rule as
-	# quality above (meaningless with AI-3D off or SBS active).
+	# Hidden again (2026-08-20) - the 2026-08-19 re-enable (for on-device
+	# DMap inspection while comparing depth models) was only meant for that
+	# comparison work and got shipped to main by accident. Not folded into
+	# sub_disabled above since that's meant to reflect "would be usable if
+	# AI-3D were on," and this one's just off regardless. Godot's
+	# Button.disabled blocks button_down from firing regardless of
+	# visibility, so this still stays fully non-interactive too.
 	if main._ui_3d_debug_btn:
-		main._ui_3d_debug_btn.visible = true
-		main._ui_3d_debug_btn.disabled = sub_disabled
-		main._ui_3d_debug_btn.modulate.a = 0.3 if sub_disabled else 1.0
+		main._ui_3d_debug_btn.disabled = true
+		main._ui_3d_debug_btn.visible = false
 
 func update_monitor_tab():
 	if not main._ui_apply_preset_btn:
@@ -548,7 +551,12 @@ func build_ui():
 	disp_row1.add_child(main._ui_3d_btn)
 	main._ui_3d_quality_btn = make_option_btn("3D Quality", "Auto")
 	disp_row1.add_child(main._ui_3d_quality_btn)
+	# Hidden until update_3d_btn_state() runs (which also happens to set
+	# this every time regardless) - set here too so there's no one-frame
+	# flash of a visible "3D Debug" button before that first fires.
 	main._ui_3d_debug_btn = make_option_btn("3D Debug", "Off")
+	main._ui_3d_debug_btn.disabled = true
+	main._ui_3d_debug_btn.visible = false
 	disp_row1.add_child(main._ui_3d_debug_btn)
 
 	var disp_gap1 = Control.new()


### PR DESCRIPTION
Fixes #17.

## Summary

- **Root cause**: `resize_screen_to_aspect()` preferred `s.monitor.frame_rect.size` over the real decoded stream dimensions whenever a monitor spec existed. Correct for genuine multi-monitor manifests (Polaris hosts report real per-output resolution there), but wrong for any single-screen/non-manifest host (Sunshine, GameStream, etc.) - that monitor spec is just whatever the welcome screen's fixed 16:9 placeholder last set, never updated again. A 21:9 source ended up squeezed into a 16:9-shaped screen.
- **Fix**: the VR screen mesh now always resizes to the real content's aspect ratio. `resize_to_aspect()` already keeps width anchored to the screen's current grid-cell footprint and only adjusts height, so this fits naturally into the existing monitor-grid math without needing to rework bezel/grab-bar/grid placement.
- **Second bug this surfaced**: `depth_estimator.gd`'s AI-3D warp gather sized its internal working resolution off `main.native_resolution`, which - same root pattern as above - is only ever updated from a real host manifest and stays stale for Sunshine. This caused a garbled horizontal band with AI-3D on, specifically at 21:9 2K. Now sourced from `main.stream_viewport.size`, which is always current regardless of host type.
- **Resolution list**: the single `21:9` option is split into `21:9 HD` (2560x1080) and `21:9 2K` (3440x1440), matching the HD/2K split every other aspect ratio already has.
- Also reverts an accidental main-branch ship of the AI-3D debug menu ("3D Debug" button) - was only meant for temporary on-device depth-model comparison work, not a real feature.

A shader-side letterbox/pillarbox approach was tried first (kept the mesh at a fixed 16:9 shape and inset the video within it) and worked, but real mesh resizing is the better fix long-term for future multi-monitor grid work, per discussion on the issue.

## Test plan

- [x] `godot --headless --check-only` exits 0
- [x] Release build + install on Quest 3, boot-check: no crash, no shader errors
- [x] Live-tested against a real 21:9 Sunshine source (2560x1080 and 3440x1440, via a custom EDID-added ultrawide mode) - both HD and 2K confirmed working correctly by the reporter, including AI-3D depth conversion
- [x] 4:3 not yet explicitly re-tested live but goes through the same code path