### PR TITLE
Native AI-3D depth on Linux (MiDaS) + local-capture monitor fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,8 @@ Nightfall-*.AppImage
 Nightfall-Linux-x86_64
 Nightfall-Linux.pck
 Nightfall.AppDir/
+/depth_models/
+/.linux-build-cache/
 /tmp/nf_deps/
 /docs/
 /log.txt

--- a/BUILD.md
+++ b/BUILD.md
@@ -68,7 +68,7 @@ ninja -C build/android
 bash docker-build-linux.sh
 ```
 
-`docker-build-linux.sh` builds in an Ubuntu 22.04 container (glibc 2.35) using the `Dockerfile.linux-build` image. It copies the source read-only into the container, builds, and copies the .so back to the host. The Docker image is cached after the first ~5min build.
+`docker-build-linux.sh` builds in an Ubuntu 22.04 container (glibc 2.35) using the `Dockerfile.linux-build` image. It copies the source read-only into the container, builds, and copies the .so back to the host. The Docker image is cached after the first build, but expect the FIRST build to take noticeably longer than before (~15-20min, not ~5min) - see the TFLite note below.
 
 To build on host without Docker (only if your host glibc ≤ 2.35, or you only target very new distros):
 
@@ -82,7 +82,7 @@ cmake --preset linux -DCMAKE_BUILD_TYPE=Release
 ninja -C build/linux-release
 ```
 
-Either way, the output is `bin/linux/libnightfall-stream.linux.template_release.x86_64.so` (~29MB stripped). AI 3D / depth estimation is stubbed on Linux.
+Either way, the output is `bin/linux/libnightfall-stream.linux.template_release.x86_64.so`. AI 3D depth estimation works natively on Linux (2026-08-20) - MiDaS-192/256 only for now (no vendor NNAPI HAL on Quest either, so CPU-only isn't a capability downgrade vs Android; YOLO26/DA V2 aren't ported yet). No vcpkg `tensorflow-lite` port exists, so `CMakeLists.txt` vendors TFLite's own standalone CMake build directly via `FetchContent` (pinned to `v2.16.1`, matching the Android build's Gradle dependency) - this needs network access at CMake-configure time (not just `docker build` time) and is what makes the first build slower. The two MiDaS `.tflite` models ship as loose files next to the binary (`depth_models/`, populated by `build.sh`) rather than through Godot's PCK, since the Linux PCK export (below) never includes `android/src/main/assets/`.
 
 ### Patched Godot Engine (Quest only)
 

--- a/Dockerfile.linux-build
+++ b/Dockerfile.linux-build
@@ -20,6 +20,8 @@ RUN apt-get update && apt-get install -y \
     libsystemd-dev \
     libx11-dev \
     libxext-dev \
+    libxrandr-dev \
+    gdb \
     && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/microsoft/vcpkg.git /opt/vcpkg \

--- a/addons/nightfall-stream/CMakeLists.txt
+++ b/addons/nightfall-stream/CMakeLists.txt
@@ -61,6 +61,37 @@ if(TARGET_PLATFORM STREQUAL "steamos" OR TARGET_PLATFORM STREQUAL "linux")
     find_package(X11 QUIET)
 endif()
 
+# Native AI-3D depth estimation on Linux (2026-08-20) - Android's depth pipeline
+# calls TFLite via JNI into DepthEstimator.java; there's no JVM on desktop Linux,
+# so this needs a direct C++ TFLite dependency instead. No vcpkg tensorflow-lite
+# port exists (only the full Bazel-built "tensorflow"/"tensorflow-cc" ports,
+# hours to build from source - the wrong tool here), so vendor TFLite's own
+# official standalone CMake build directly (tensorflow/lite has first-class
+# CMake support independent of Bazel/full TF - see
+# tensorflow.org/lite/guide/build_cmake) via FetchContent. Pinned to v2.16.1 to
+# match the Android build's own org.tensorflow:tensorflow-lite Gradle dependency
+# (see build.sh) for op-version/behavior parity between platforms. Linux only
+# (not steamos) - matches this feature's initial scope.
+if(TARGET_PLATFORM STREQUAL "linux")
+    include(FetchContent)
+    FetchContent_Declare(
+        tensorflow
+        GIT_REPOSITORY https://github.com/tensorflow/tensorflow.git
+        GIT_TAG v2.16.1
+        GIT_SHALLOW TRUE
+    )
+    FetchContent_GetProperties(tensorflow)
+    if(NOT tensorflow_POPULATED)
+        FetchContent_Populate(tensorflow)
+        # TFLite's own CMakeLists.txt is a standalone entry point (not the full
+        # TF build) - produces a "tensorflow-lite" target with public headers,
+        # FetchContent-pulling its own small deps (flatbuffers, ruy, xnnpack,
+        # etc.) internally. EXCLUDE_FROM_ALL so its own test/tool targets don't
+        # build as part of our default target.
+        add_subdirectory("${tensorflow_SOURCE_DIR}/tensorflow/lite" "${CMAKE_CURRENT_BINARY_DIR}/tflite-build" EXCLUDE_FROM_ALL)
+    endif()
+endif()
+
 if(DEFINED GODOTCPP_SUFFIX AND NOT GODOTCPP_SUFFIX STREQUAL "")
     set(GODOTCPP_SUFFIX_INTERNAL "${GODOTCPP_SUFFIX}")
 elseif(DEFINED ENV{GODOTCPP_SUFFIX})
@@ -135,9 +166,31 @@ if(TARGET_PLATFORM STREQUAL "steamos" OR TARGET_PLATFORM STREQUAL "linux")
     if(X11_FOUND)
         target_link_libraries(${LIBNAME} PRIVATE X11::X11 X11::Xext)
         target_compile_definitions(${LIBNAME} PRIVATE NIGHTFALL_HAS_X11)
+        # RandR monitor enumeration for local-capture mode's per-monitor
+        # selection (2026-08-20, x11_capture.cpp's select_capture_region()) -
+        # without this the local-capture zero-copy path always grabbed the
+        # WHOLE X11 root window (every connected monitor unioned together),
+        # not just whichever one Sunshine is actually configured to stream.
+        if(X11_Xrandr_FOUND)
+            target_link_libraries(${LIBNAME} PRIVATE X11::Xrandr)
+            target_compile_definitions(${LIBNAME} PRIVATE NIGHTFALL_HAS_XRANDR)
+        endif()
     endif()
     if(TARGET_PLATFORM STREQUAL "linux")
         set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic")
+        target_link_libraries(${LIBNAME} PRIVATE tensorflow-lite)
+
+        # Standalone MidasDepthEngine reproduction harness (2026-08-20 segfault
+        # investigation) - NOT part of the normal build, opt-in only
+        # (-DNIGHTFALL_BUILD_MIDAS_TEST=ON) so it doesn't cost anything in the
+        # real build.sh flow. Lets the engine be exercised/debugged (gdb)
+        # directly without needing a live Sunshine stream or the app's UI.
+        if(NIGHTFALL_BUILD_MIDAS_TEST)
+            add_executable(midas_test src/video/midas_test_main.cpp src/video/midas_depth_engine.cpp)
+            target_compile_features(midas_test PRIVATE cxx_std_17)
+            target_include_directories(midas_test PRIVATE src)
+            target_link_libraries(midas_test PRIVATE tensorflow-lite pthread)
+        endif()
     endif()
 endif()
 

--- a/addons/nightfall-stream/src/nightfall_stream.cpp
+++ b/addons/nightfall-stream/src/nightfall_stream.cpp
@@ -345,8 +345,16 @@ bool NightfallStream::is_display_ready() const {
 // GodotApp.getCodecCapabilitiesInfo()), rather than inferring them from trial
 // and error. Not on any hot path - call once from GDScript and read the result
 // from logcat/the returned string.
+// Pre-existing Linux-build bug (found 2026-08-20 while adding native AI-3D
+// depth on Linux, unrelated to that work) - JavaVM/jclass were declared here
+// unconditionally, with only the FUNCTION BODY below guarded by
+// #ifdef __ANDROID__. On Android something else transitively pulls in
+// <jni.h> before this point so it happened to compile; on Linux nothing ever
+// defines those types at all, failing the whole target's build outright.
+#ifdef __ANDROID__
 extern JavaVM *nightfall_get_jvm();
 extern jclass nightfall_get_godot_app_class();
+#endif
 
 String NightfallStream::get_codec_capabilities_info() const {
 #ifdef __ANDROID__

--- a/addons/nightfall-stream/src/nightfall_stream.cpp
+++ b/addons/nightfall-stream/src/nightfall_stream.cpp
@@ -285,6 +285,28 @@ bool NightfallStream::get_local_capture_mode() const {
     return local_capture_mode_;
 }
 
+// Ground-truth diagnostic (2026-08-21, Linux vertical-click investigation) -
+// surfaces the ACTUAL region x11_capture_ grabbed (offset + size within the
+// X11 root window), so GDScript can compare it against what it assumes
+// (resolutions[idx]/layout.frame_size) instead of trusting those blindly.
+// {} (empty dict, all zero) when local capture isn't active - callers should
+// treat that as "no region info available", not "0x0 capture region".
+Dictionary NightfallStream::get_local_capture_region() const {
+    Dictionary d;
+    if (!x11_capture_) {
+        d["width"] = 0;
+        d["height"] = 0;
+        d["x"] = 0;
+        d["y"] = 0;
+        return d;
+    }
+    d["width"] = (int)x11_capture_->get_width();
+    d["height"] = (int)x11_capture_->get_height();
+    d["x"] = x11_capture_->get_x_offset();
+    d["y"] = x11_capture_->get_y_offset();
+    return d;
+}
+
 Ref<FfmpegDecoder> NightfallStream::get_decoder() const {
     if (stream_connection_) return stream_connection_->get_decoder();
     return nullptr;
@@ -587,6 +609,7 @@ void NightfallStream::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_reconnect_delay_ms"), &NightfallStream::get_reconnect_delay_ms);
     ClassDB::bind_method(D_METHOD("set_local_capture_mode", "enabled"), &NightfallStream::set_local_capture_mode);
     ClassDB::bind_method(D_METHOD("get_local_capture_mode"), &NightfallStream::get_local_capture_mode);
+    ClassDB::bind_method(D_METHOD("get_local_capture_region"), &NightfallStream::get_local_capture_region);
     ClassDB::bind_method(D_METHOD("set_restore_token", "token"), &NightfallStream::set_restore_token);
     ClassDB::bind_method(D_METHOD("get_restore_token"), &NightfallStream::get_restore_token);
 

--- a/addons/nightfall-stream/src/nightfall_stream.h
+++ b/addons/nightfall-stream/src/nightfall_stream.h
@@ -59,6 +59,7 @@ public:
 
     void set_local_capture_mode(bool enabled);
     bool get_local_capture_mode() const;
+    Dictionary get_local_capture_region() const;
     void set_restore_token(const String &token);
     String get_restore_token() const;
 

--- a/addons/nightfall-stream/src/video/depth_bridge.cpp
+++ b/addons/nightfall-stream/src/video/depth_bridge.cpp
@@ -1,6 +1,29 @@
 #include "depth_bridge.h"
 #include "nf_log.h"
 
+#ifdef NIGHTFALL_PLATFORM_LINUX
+#include "midas_depth_engine.h"
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include <godot_cpp/classes/os.hpp>
+
+// Loose files next to the running executable, NOT through Godot's res:///PCK
+// - build.sh's Linux PCK export (--export-pack, using the Android preset as
+// a headless-export workaround) never includes android/src/main/assets/, so
+// fighting the resource/import pipeline for two ~17MB binary blobs isn't
+// worth it. Mirrors the exact pattern already used for the GDExtension .so
+// itself and the Meta OpenXR vendor plugin AAR - see build.sh's AppImage-
+// assembly section for where "depth_models/" actually gets populated.
+static std::string nightfall_resolve_model_dir() {
+    godot::String exe_path = godot::OS::get_singleton()->get_executable_path();
+    godot::String dir = exe_path.get_base_dir();
+    return std::string((dir + "/depth_models").utf8().get_data());
+}
+#endif
+
 #ifdef __ANDROID__
 #include <jni.h>
 #include <android/log.h>
@@ -43,8 +66,21 @@ using namespace godot;
 DepthBridge::DepthBridge() {}
 DepthBridge::~DepthBridge() {}
 
+#ifdef NIGHTFALL_PLATFORM_LINUX
+void DepthBridge::ensure_midas_engine() {
+    if (midas_engine_) return;
+    midas_engine_ = std::make_unique<MidasDepthEngine>();
+    midas_engine_->initialize(nightfall_resolve_model_dir());
+}
+#endif
+
 void DepthBridge::submit_depth_frame(const PackedByteArray &frame_data, int width, int height) {
-#ifdef __ANDROID__
+#ifdef NIGHTFALL_PLATFORM_LINUX
+    ensure_midas_engine();
+    if (midas_engine_) {
+        midas_engine_->submit_frame(frame_data.ptr(), (size_t)frame_data.size(), width, height);
+    }
+#elif defined(__ANDROID__)
     JNIEnv *env = get_jni_env();
     if (!env) return;
 
@@ -67,7 +103,15 @@ void DepthBridge::submit_depth_frame(const PackedByteArray &frame_data, int widt
 
 PackedByteArray DepthBridge::get_depth_map() {
     PackedByteArray empty;
-#ifdef __ANDROID__
+#ifdef NIGHTFALL_PLATFORM_LINUX
+    if (!midas_engine_) return empty;
+    std::vector<uint8_t> depth = midas_engine_->get_latest_depth();
+    if (depth.empty()) return empty;
+    PackedByteArray depth_data;
+    depth_data.resize(depth.size());
+    memcpy(depth_data.ptrw(), depth.data(), depth.size());
+    return depth_data;
+#elif defined(__ANDROID__)
     JNIEnv *env = get_jni_env();
     if (!env) return empty;
 
@@ -102,7 +146,12 @@ PackedByteArray DepthBridge::get_depth_map() {
 }
 
 void DepthBridge::set_depth_model(int model_index) {
-#ifdef __ANDROID__
+#ifdef NIGHTFALL_PLATFORM_LINUX
+    ensure_midas_engine();
+    if (midas_engine_) {
+        midas_engine_->set_active_model(model_index);
+    }
+#elif defined(__ANDROID__)
     JNIEnv *env = get_jni_env();
     if (!env) {
         __android_log_print(ANDROID_LOG_ERROR, "DepthBridge", "set_depth_model: no JNIEnv");
@@ -130,7 +179,10 @@ void DepthBridge::set_depth_model(int model_index) {
 }
 
 int DepthBridge::get_depth_model_size() {
-#ifdef __ANDROID__
+#ifdef NIGHTFALL_PLATFORM_LINUX
+    if (!midas_engine_) return 256;
+    return midas_engine_->get_model_size();
+#elif defined(__ANDROID__)
     JNIEnv *env = get_jni_env();
     if (!env) return 256;
 

--- a/addons/nightfall-stream/src/video/depth_bridge.h
+++ b/addons/nightfall-stream/src/video/depth_bridge.h
@@ -3,6 +3,11 @@
 #include <godot_cpp/classes/ref_counted.hpp>
 #include <godot_cpp/variant/packed_byte_array.hpp>
 
+#ifdef NIGHTFALL_PLATFORM_LINUX
+#include <memory>
+class MidasDepthEngine;
+#endif
+
 namespace godot {
 
 class DepthBridge : public RefCounted {
@@ -19,6 +24,16 @@ public:
 
 protected:
     static void _bind_methods();
+
+private:
+#ifdef NIGHTFALL_PLATFORM_LINUX
+    // Native (JNI-free) MiDaS-only depth engine - see midas_depth_engine.h.
+    // Lazily constructed/initialized on first use (submit_depth_frame() or
+    // set_depth_model()) rather than in the constructor, so a DepthBridge
+    // that's never actually used for AI-3D never pays the model-load cost.
+    std::unique_ptr<MidasDepthEngine> midas_engine_;
+    void ensure_midas_engine();
+#endif
 };
 
 } // namespace godot

--- a/addons/nightfall-stream/src/video/midas_depth_engine.cpp
+++ b/addons/nightfall-stream/src/video/midas_depth_engine.cpp
@@ -1,0 +1,345 @@
+#include "midas_depth_engine.h"
+#include "nf_log.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstring>
+
+#include "tensorflow/lite/interpreter.h"
+#include "tensorflow/lite/kernels/register.h"
+#include "tensorflow/lite/model.h"
+
+namespace {
+constexpr const char *TAG = "MidasDepthEngine";
+constexpr int HIST_BINS = 512;
+constexpr float DEFAULT_PERCENTILE_CLIP = 0.02f;
+// Same values as DepthEstimator.java's RANGE_TAU_SECONDS/DEPTH_TAU_SECONDS -
+// see that file's comment for the derivation (tau = dt_ref / -ln(1 - alpha)
+// against MiDaS's own typical ~145ms achieved cadence).
+constexpr float RANGE_TAU_SECONDS = 0.89f;
+constexpr float DEPTH_TAU_SECONDS = 0.158f;
+
+int64_t now_ns() {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
+} // namespace
+
+MidasDepthEngine::MidasDepthEngine() {}
+
+MidasDepthEngine::~MidasDepthEngine() {
+    {
+        std::lock_guard<std::mutex> lock(submit_mutex_);
+        shutdown_ = true;
+    }
+    submit_cv_.notify_all();
+    if (worker_.joinable()) {
+        worker_.join();
+    }
+}
+
+bool MidasDepthEngine::load_model(MidasModel &model, const std::string &path, const char *name, int size) {
+    model.name = name;
+    model.size = size;
+    model.flat_model = tflite::FlatBufferModel::BuildFromFile(path.c_str());
+    if (!model.flat_model) {
+        NF_LOGE(TAG, "Failed to load model file: %s", path.c_str());
+        return false;
+    }
+
+    tflite::ops::builtin::BuiltinOpResolver resolver;
+    tflite::InterpreterBuilder builder(*model.flat_model, resolver);
+    builder(&model.interpreter);
+    if (!model.interpreter) {
+        NF_LOGE(TAG, "Failed to build interpreter for: %s", path.c_str());
+        return false;
+    }
+
+    model.interpreter->SetNumThreads(4);
+    if (model.interpreter->AllocateTensors() != kTfLiteOk) {
+        NF_LOGE(TAG, "AllocateTensors failed for: %s", path.c_str());
+        return false;
+    }
+
+    // Read quantization params directly from the loaded model's own tensor
+    // metadata (see midas_depth_engine.h's comment) rather than hardcoding -
+    // both MiDaS-192 and MiDaS-256 are w8a8 (uint8 I/O), each independently
+    // calibrated.
+    const TfLiteTensor *input_tensor = model.interpreter->input_tensor(0);
+    const TfLiteTensor *output_tensor = model.interpreter->output_tensor(0);
+    model.input_scale = input_tensor->params.scale;
+    model.input_zero_point = input_tensor->params.zero_point;
+    model.output_scale = output_tensor->params.scale;
+    model.output_zero_point = output_tensor->params.zero_point;
+
+    model.loaded = true;
+    NF_LOG(TAG, "Loaded %s (%dx%d, in_scale=%f in_zp=%d out_scale=%f out_zp=%d)",
+           name, size, size, model.input_scale, model.input_zero_point,
+           model.output_scale, model.output_zero_point);
+    return true;
+}
+
+void MidasDepthEngine::initialize(const std::string &model_dir) {
+    if (initialized_) return;
+
+    bool ok_256 = load_model(model_256_, model_dir + "/midas-midas-v2-w8a8.tflite", "MiDaS-256", 256);
+    bool ok_192 = load_model(model_192_, model_dir + "/midas-v21-small-192-int8.tflite", "MiDaS-192", 192);
+
+    if (!ok_256 && !ok_192) {
+        NF_LOGE(TAG, "No MiDaS models could be loaded from %s - AI-3D depth unavailable", model_dir.c_str());
+        return;
+    }
+
+    active_model_ = ok_256 ? &model_256_ : &model_192_;
+    active_model_index_ = ok_256 ? 3 : 10;
+    initialized_ = true;
+    worker_ = std::thread(&MidasDepthEngine::worker_loop, this);
+    NF_LOG(TAG, "Initialized (MiDaS-256=%s, MiDaS-192=%s)", ok_256 ? "true" : "false", ok_192 ? "true" : "false");
+}
+
+void MidasDepthEngine::set_active_model(int model_index) {
+    if (!initialized_) return;
+
+    MidasModel *target = &model_256_;
+    if (model_index == 10 && model_192_.loaded) {
+        target = &model_192_;
+    } else if (model_192_.loaded == false && model_256_.loaded == false) {
+        return;
+    } else if (!model_256_.loaded) {
+        // Only MiDaS-192 loaded successfully - fall back to it regardless
+        // of what was requested, same "always land on something loaded"
+        // intent as DepthEstimator.java's own fallback chain.
+        target = &model_192_;
+    }
+
+    if (active_model_ == target) return;
+
+    // Wait out any in-flight inference before switching, same as
+    // DepthEstimator.java's setActiveModel() busy-wait - avoids a race
+    // where a result computed against the OLD model lands after the switch.
+    while (is_inferencing_.load()) {
+        std::this_thread::yield();
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(postprocess_mutex_);
+        smoothed_valid_ = false;
+        range_valid_ = false;
+        last_post_process_time_ns_ = 0;
+    }
+    active_model_ = target;
+    active_model_index_ = (target == &model_192_) ? 10 : 3;
+    NF_LOG(TAG, "Switched to model %s", target->name.c_str());
+}
+
+int MidasDepthEngine::get_model_size() const {
+    MidasModel *model = active_model_.load();
+    if (!initialized_ || !model) return 256;
+    return model->size;
+}
+
+void MidasDepthEngine::submit_frame(const uint8_t *rgba, size_t rgba_len, int width, int height) {
+    if (!initialized_ || !active_model_) return;
+    if (!rgba || width <= 0 || height <= 0) return;
+    if (is_inferencing_.load()) return; // drop - matches Android's isInferencing.compareAndSet policy
+
+    size_t needed = static_cast<size_t>(width) * static_cast<size_t>(height) * 4;
+    if (rgba_len < needed) {
+        // Real bug found 2026-08-20: depth_viewport's SubViewport resize
+        // (192<->256, switching MiDaS models) doesn't necessarily apply to
+        // the very next captured frame synchronously, so width/height (from
+        // the just-updated model_size) can briefly disagree with the
+        // ACTUAL captured image's real buffer size - reading needed bytes
+        // from a smaller buffer segfaulted. Drop this one frame instead;
+        // the next submit (after the viewport catches up) will be correctly
+        // sized again.
+        NF_LOGE("MidasDepthEngine", "submit_frame: buffer too small (got %zu, need %zu for %dx%d) - dropping frame",
+                rgba_len, needed, width, height);
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(submit_mutex_);
+        pending_rgba_.assign(rgba, rgba + needed);
+        pending_width_ = width;
+        pending_height_ = height;
+        has_pending_ = true;
+    }
+    submit_cv_.notify_one();
+}
+
+std::vector<uint8_t> MidasDepthEngine::get_latest_depth() {
+    std::lock_guard<std::mutex> lock(result_mutex_);
+    if (!has_result_) return {};
+    has_result_ = false;
+    return std::move(latest_result_);
+}
+
+void MidasDepthEngine::worker_loop() {
+    while (true) {
+        std::vector<uint8_t> rgba;
+        int width = 0, height = 0;
+        {
+            std::unique_lock<std::mutex> lock(submit_mutex_);
+            submit_cv_.wait(lock, [this] { return has_pending_ || shutdown_; });
+            if (shutdown_) return;
+            rgba = std::move(pending_rgba_);
+            width = pending_width_;
+            height = pending_height_;
+            has_pending_ = false;
+        }
+
+        is_inferencing_.store(true);
+        MidasModel *model = active_model_;
+        if (model && model->loaded) {
+            std::vector<float> raw = run_inference(*model, rgba.data(), width, height);
+            std::vector<uint8_t> depth = post_process(raw, model->size);
+            std::lock_guard<std::mutex> lock(result_mutex_);
+            latest_result_ = std::move(depth);
+            has_result_ = true;
+        }
+        is_inferencing_.store(false);
+    }
+}
+
+std::vector<float> MidasDepthEngine::run_inference(MidasModel &model, const uint8_t *rgba, int width, int height) {
+    const int size = model.size;
+    uint8_t *input_data = model.interpreter->typed_input_tensor<uint8_t>(0);
+
+    const int src_row_bytes = width * 4;
+    const float scale_x = static_cast<float>(width) / size;
+    const float scale_y = static_cast<float>(height) / size;
+    const float in_scale = model.input_scale;
+    const int in_zero_point = model.input_zero_point;
+
+    int idx = 0;
+    for (int y = 0; y < size; y++) {
+        int src_y = std::min(static_cast<int>(y * scale_y), height - 1);
+        int src_row_off = src_y * src_row_bytes;
+        for (int x = 0; x < size; x++) {
+            int src_x = std::min(static_cast<int>(x * scale_x), width - 1);
+            int src_idx = src_row_off + src_x * 4;
+            for (int c = 0; c < 3; c++) {
+                float real = rgba[src_idx + c] / 255.0f;
+                int q = static_cast<int>(std::lround(real / in_scale)) + in_zero_point;
+                q = std::max(0, std::min(255, q));
+                input_data[idx++] = static_cast<uint8_t>(q);
+            }
+        }
+    }
+
+    model.interpreter->Invoke();
+
+    const uint8_t *output_data = model.interpreter->typed_output_tensor<uint8_t>(0);
+    const int count = size * size;
+    const float out_scale = model.output_scale;
+    const int out_zero_point = model.output_zero_point;
+    std::vector<float> raw(count);
+    for (int i = 0; i < count; i++) {
+        raw[i] = (static_cast<int>(output_data[i]) - out_zero_point) * out_scale;
+    }
+    return raw;
+}
+
+void MidasDepthEngine::robust_range(const std::vector<float> &v, float *lo_out, float *hi_out) const {
+    const int count = static_cast<int>(v.size());
+    float lo = v[0], hi = v[0];
+    for (int i = 1; i < count; i++) {
+        lo = std::min(lo, v[i]);
+        hi = std::max(hi, v[i]);
+    }
+    if (hi <= lo) {
+        *lo_out = lo;
+        *hi_out = lo + 1.0f;
+        return;
+    }
+
+    int hist[HIST_BINS] = {0};
+    float bin_scale = HIST_BINS / (hi - lo);
+    for (int i = 0; i < count; i++) {
+        int b = static_cast<int>((v[i] - lo) * bin_scale);
+        b = std::max(0, std::min(HIST_BINS - 1, b));
+        hist[b]++;
+    }
+
+    int lo_target = static_cast<int>(count * DEFAULT_PERCENTILE_CLIP);
+    int hi_target = static_cast<int>(count * (1.0f - DEFAULT_PERCENTILE_CLIP));
+    int acc = 0;
+    int lo_bin = 0, hi_bin = HIST_BINS - 1;
+    for (int b = 0; b < HIST_BINS; b++) {
+        acc += hist[b];
+        if (acc >= lo_target) {
+            lo_bin = b;
+            break;
+        }
+    }
+    acc = 0;
+    for (int b = 0; b < HIST_BINS; b++) {
+        acc += hist[b];
+        if (acc >= hi_target) {
+            hi_bin = b;
+            break;
+        }
+    }
+
+    float bin_width = (hi - lo) / HIST_BINS;
+    float robust_lo = lo + lo_bin * bin_width;
+    float robust_hi = lo + (hi_bin + 1) * bin_width;
+    if (robust_hi <= robust_lo) {
+        robust_hi = robust_lo + 1e-3f;
+    }
+    *lo_out = robust_lo;
+    *hi_out = robust_hi;
+}
+
+std::vector<uint8_t> MidasDepthEngine::post_process(const std::vector<float> &raw, int size) {
+    std::lock_guard<std::mutex> lock(postprocess_mutex_);
+    const int count = size * size;
+
+    int64_t now = now_ns();
+    float dt = last_post_process_time_ns_ == 0
+                   ? DEPTH_TAU_SECONDS
+                   : std::max(1.0f / 60.0f, std::min((now - last_post_process_time_ns_) / 1e9f, 1.0f));
+    last_post_process_time_ns_ = now;
+
+    float lo, hi;
+    robust_range(raw, &lo, &hi);
+    if (!range_valid_) {
+        smooth_lo_ = lo;
+        smooth_hi_ = hi;
+        range_valid_ = true;
+    } else {
+        float range_alpha = 1.0f - std::exp(-dt / RANGE_TAU_SECONDS);
+        smooth_lo_ += range_alpha * (lo - smooth_lo_);
+        smooth_hi_ += range_alpha * (hi - smooth_hi_);
+    }
+    float scale = 1.0f / std::max(smooth_hi_ - smooth_lo_, 1e-6f);
+
+    std::vector<float> normalized(count);
+    for (int i = 0; i < count; i++) {
+        float v = (raw[i] - smooth_lo_) * scale;
+        normalized[i] = std::max(0.0f, std::min(1.0f, v));
+    }
+
+    // temporalSmooth() ported inline - per-texel EMA at DEPTH_TAU_SECONDS,
+    // same reasoning as DepthEstimator.java (a rate that never truly
+    // reaches zero keeps denoising even on a fully static desktop).
+    if (!smoothed_valid_ || static_cast<int>(smoothed_depth_.size()) != count) {
+        smoothed_depth_ = normalized;
+        smoothed_valid_ = true;
+    } else {
+        float depth_alpha = 1.0f - std::exp(-dt / DEPTH_TAU_SECONDS);
+        for (int i = 0; i < count; i++) {
+            smoothed_depth_[i] += depth_alpha * (normalized[i] - smoothed_depth_[i]);
+        }
+    }
+
+    std::vector<uint8_t> depth_bytes(count);
+    for (int i = 0; i < count; i++) {
+        float v = std::max(0.0f, std::min(1.0f, smoothed_depth_[i]));
+        depth_bytes[i] = static_cast<uint8_t>(v * 255.0f);
+    }
+    return depth_bytes;
+}

--- a/addons/nightfall-stream/src/video/midas_depth_engine.h
+++ b/addons/nightfall-stream/src/video/midas_depth_engine.h
@@ -1,0 +1,150 @@
+#pragma once
+
+// Native (JNI-free) MiDaS depth estimation for Linux - a direct C++ port of
+// DepthEstimator.java's MiDaS-only subset (MiDaS-192/256), used by
+// depth_bridge.cpp's NIGHTFALL_PLATFORM_LINUX branch. Same math/algorithm as
+// the Java version (robustRange/postProcess/temporalSmooth), same async
+// single-inference-in-flight submit/drop semantics (mirrors Java's single-
+// thread ExecutorService + AtomicBoolean isInferencing), just without the
+// JNI hop - there's no JVM on desktop Linux. YOLO26/DA V2 are NOT ported
+// here yet (see the depth-model-comparison work's DepthEstimator.java for
+// what a future port needs) - any model index this doesn't recognize falls
+// back to MiDaS-256, matching DepthEstimator.java's own
+// setActiveModel()/else-branch fallback for unreachable/dormant indices.
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+// Can't forward-declare these - as of TFLite v2.16.1, tflite::Interpreter is
+// itself a type ALIAS (`using Interpreter = impl::Interpreter;` in
+// tensorflow/lite/core/interpreter.h), not a plain class in the tflite
+// namespace, so a `class Interpreter;` forward declaration is an invalid
+// conflicting redeclaration once the real header is included elsewhere in
+// the same translation unit. Including the real headers here is fine -
+// they're include-guarded, and this header is only ever included from
+// midas_depth_engine.cpp and depth_bridge.cpp (which only forward-declares
+// MidasDepthEngine itself, not any TFLite type).
+#include "tensorflow/lite/interpreter.h"
+#include "tensorflow/lite/model.h"
+
+class MidasDepthEngine {
+public:
+    MidasDepthEngine();
+    ~MidasDepthEngine();
+
+    // Loads both MiDaS models from the given directory (see depth_bridge.cpp
+    // for how that directory is resolved - loose files next to the
+    // executable, not through Godot's res:///PCK, same pattern as the
+    // GDExtension .so itself). Safe to call once; subsequent calls are a
+    // no-op if already initialized.
+    void initialize(const std::string &model_dir);
+
+    // rgba: expected to be width*height*4 bytes (RGBA8, matching
+    // depth_viewport's SubViewport format on the GDScript side) - rgba_len
+    // is the CALLER's actual buffer size and is checked against that
+    // expectation before anything is read from it. Non-blocking - drops the
+    // frame if an inference is already in flight (same policy as
+    // DepthEstimator.java's submitFrame()) or if rgba_len is too small
+    // (found 2026-08-20: depth_viewport.size can change (192<->256) when
+    // switching MiDaS-192/256, and a Godot SubViewport resize doesn't
+    // necessarily apply to the very next captured frame synchronously -
+    // trusting width/height without checking the real buffer size crashed
+    // on a real switch, this is the fix).
+    void submit_frame(const uint8_t *rgba, size_t rgba_len, int width, int height);
+
+    // Returns the most recent completed depth map (size*size single-channel
+    // bytes) and clears it, or an empty vector if nothing new since the last
+    // call - mirrors DepthBridge::get_depth_map()'s existing contract.
+    std::vector<uint8_t> get_latest_depth();
+
+    // Same model-index scheme main.gd/settings_controller.gd already send on
+    // every platform (3=MiDaS-256, 10=MiDaS-192) - see
+    // DepthEstimator.java's setActiveModel() for the authoritative mapping.
+    // Any other index falls back to MiDaS-256.
+    void set_active_model(int model_index);
+
+    // Native output resolution (square) of whichever model is currently
+    // active - depth_estimator.gd sizes its capture viewport off this via
+    // DepthBridge::get_depth_model_size(), same as Android.
+    int get_model_size() const;
+
+private:
+    struct MidasModel {
+        std::string name;
+        int size = 0;
+        std::unique_ptr<tflite::FlatBufferModel> flat_model;
+        std::unique_ptr<tflite::Interpreter> interpreter;
+        // Read directly from the loaded model's own tensor metadata at load
+        // time (ai-edge-litert Interpreter.get_input/output_details()'
+        // pattern already established for this project's Python tooling) -
+        // NOT hardcoded. Getting either wrong doesn't throw, it silently
+        // produces garbage depth data (this exact failure mode already bit
+        // this project once on Android, see git history).
+        float input_scale = 1.0f;
+        int input_zero_point = 0;
+        float output_scale = 1.0f;
+        int output_zero_point = 0;
+        bool loaded = false;
+    };
+
+    bool load_model(MidasModel &model, const std::string &path, const char *name, int size);
+    // Fills the interpreter's input tensor (NHWC, quantized uint8, same
+    // nearest-neighbor downscale as DepthEstimator.java's runInferenceMidas()),
+    // runs inference, dequantizes the output, and returns raw (unnormalized)
+    // depth values in model.size*model.size row-major order.
+    std::vector<float> run_inference(MidasModel &model, const uint8_t *rgba, int width, int height);
+
+    // Ported verbatim from DepthEstimator.java - see its own comments for
+    // the full reasoning (percentile-clip histogram range, dt-scaled EMA
+    // smoothing via RANGE_TAU_SECONDS/DEPTH_TAU_SECONDS, per-texel temporal
+    // smoothing). dilateAndBlur is never used here (MiDaS's own call site on
+    // Android never sets it either - the warp shader's own joint-bilateral
+    // upsample already does edge-aware smoothing).
+    void robust_range(const std::vector<float> &v, float *lo_out, float *hi_out) const;
+    std::vector<uint8_t> post_process(const std::vector<float> &raw, int size);
+
+    void worker_loop();
+
+    MidasModel model_256_;
+    MidasModel model_192_;
+    // atomic - written from the calling thread (set_active_model()) and
+    // read from worker_loop() on the dedicated inference thread; a plain
+    // pointer here would be a real data race even though it happened not to
+    // be the cause of the 2026-08-20 segfault (see submit_frame()'s rgba_len
+    // check for that one).
+    std::atomic<MidasModel *> active_model_{nullptr};
+    std::atomic<int> active_model_index_{3};
+
+    std::thread worker_;
+    std::mutex submit_mutex_;
+    std::condition_variable submit_cv_;
+    bool has_pending_ = false;
+    std::vector<uint8_t> pending_rgba_;
+    int pending_width_ = 0;
+    int pending_height_ = 0;
+    std::atomic<bool> is_inferencing_{false};
+    bool shutdown_ = false;
+
+    std::mutex result_mutex_;
+    std::vector<uint8_t> latest_result_;
+    bool has_result_ = false;
+
+    // postProcess()'s running state - reset whenever the active model
+    // switches (same as DepthEstimator.java's setActiveModel()).
+    std::vector<float> smoothed_depth_;
+    bool smoothed_valid_ = false;
+    float smooth_lo_ = 0.0f;
+    float smooth_hi_ = 1.0f;
+    bool range_valid_ = false;
+    int64_t last_post_process_time_ns_ = 0;
+    std::mutex postprocess_mutex_;
+
+    bool initialized_ = false;
+};

--- a/addons/nightfall-stream/src/video/midas_test_main.cpp
+++ b/addons/nightfall-stream/src/video/midas_test_main.cpp
@@ -1,0 +1,52 @@
+// Standalone reproduction harness for the 2026-08-20 Linux AI-3D segfault -
+// exercises MidasDepthEngine directly (no Godot/GDExtension/X11 capture
+// involved) so it can be run/debugged (gdb) without needing a live Sunshine
+// stream or driving the app's UI. Only built when NIGHTFALL_BUILD_MIDAS_TEST
+// is set (see CMakeLists.txt) - not part of the normal build.
+#include "midas_depth_engine.h"
+
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+static void submit_synthetic_frame(MidasDepthEngine &engine, int size) {
+    std::vector<uint8_t> rgba(static_cast<size_t>(size) * size * 4);
+    for (size_t i = 0; i < rgba.size(); i += 4) {
+        rgba[i + 0] = static_cast<uint8_t>(i % 256);
+        rgba[i + 1] = static_cast<uint8_t>((i / 4) % 256);
+        rgba[i + 2] = static_cast<uint8_t>((i / 7) % 256);
+        rgba[i + 3] = 255;
+    }
+    engine.submit_frame(rgba.data(), rgba.size(), size, size);
+}
+
+int main(int argc, char **argv) {
+    std::string model_dir = argc > 1 ? argv[1] : "depth_models";
+    printf("[test] initializing with model_dir=%s\n", model_dir.c_str());
+
+    MidasDepthEngine engine;
+    engine.initialize(model_dir);
+
+    // Mirrors the real sequence that crashed: default model (256) active,
+    // then switch to 192 right as frames start flowing, repeatedly.
+    for (int cycle = 0; cycle < 6; cycle++) {
+        int model_index = (cycle % 2 == 0) ? 10 : 3; // 10=MiDaS-192, 3=MiDaS-256
+        int size = (model_index == 10) ? 192 : 256;
+        printf("[test] cycle %d: set_active_model(%d), get_model_size()=%d\n",
+               cycle, model_index, engine.get_model_size());
+        engine.set_active_model(model_index);
+        printf("[test] cycle %d: get_model_size() after switch = %d\n", cycle, engine.get_model_size());
+
+        for (int i = 0; i < 10; i++) {
+            submit_synthetic_frame(engine, size);
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            auto depth = engine.get_latest_depth();
+            printf("[test] cycle %d frame %d: submitted, got %zu depth bytes\n", cycle, i, depth.size());
+        }
+    }
+
+    printf("[test] all cycles completed without crashing\n");
+    return 0;
+}

--- a/addons/nightfall-stream/src/video/x11_capture.cpp
+++ b/addons/nightfall-stream/src/video/x11_capture.cpp
@@ -5,12 +5,193 @@
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/extensions/XShm.h>
+#ifdef NIGHTFALL_HAS_XRANDR
+#include <X11/extensions/Xrandr.h>
+#endif
 #include <sys/shm.h>
 #include <cstdlib>
 #include <cstring>
 #include <chrono>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
 
 namespace godot {
+
+#ifdef NIGHTFALL_HAS_XRANDR
+namespace {
+
+// Best-effort: Sunshine's own "output_name" config value is an NvFBC output
+// INDEX (NVIDIA's own head enumeration, e.g. "0"), not an X11 RandR
+// connector name - there's no guarantee the two enumeration orders match,
+// so this is a heuristic, not a guarantee (see CMakeLists.txt/plan notes).
+// Checks both plausible install locations: a native/AppImage install's
+// ~/.config/sunshine/sunshine.conf, and a Flatpak install's
+// ~/.var/app/dev.lizardbyte.app.Sunshine/config/sunshine/sunshine.conf
+// (confirmed real on the dev machine this was built against). Simple
+// line-based "key = value" parsing matches Sunshine's actual config format
+// exactly - no need for a real config-file parser for one integer field.
+bool read_sunshine_output_index(int &out_index) {
+    const char *home = getenv("HOME");
+    if (!home) return false;
+
+    std::vector<std::string> candidate_paths = {
+        std::string(home) + "/.var/app/dev.lizardbyte.app.Sunshine/config/sunshine/sunshine.conf",
+        std::string(home) + "/.config/sunshine/sunshine.conf",
+    };
+
+    for (const auto &path : candidate_paths) {
+        std::ifstream f(path);
+        if (!f.is_open()) continue;
+
+        std::string line;
+        while (std::getline(f, line)) {
+            size_t eq = line.find('=');
+            if (eq == std::string::npos) continue;
+            std::string key = line.substr(0, eq);
+            std::string value = line.substr(eq + 1);
+            // Trim whitespace both sides of key/value.
+            auto trim = [](std::string &s) {
+                size_t a = s.find_first_not_of(" \t\r\n");
+                size_t b = s.find_last_not_of(" \t\r\n");
+                s = (a == std::string::npos) ? "" : s.substr(a, b - a + 1);
+            };
+            trim(key);
+            trim(value);
+            if (key == "output_name" && !value.empty()) {
+                // strtol, not std::stoi - this project builds with
+                // -fno-exceptions, so std::stoi's throw-on-invalid-input
+                // behavior isn't usable here.
+                char *end = nullptr;
+                long parsed = strtol(value.c_str(), &end, 10);
+                if (end == value.c_str() || *end != '\0') {
+                    return false; // non-numeric output_name (e.g. a real device name) - not usable here
+                }
+                out_index = (int)parsed;
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+// Active (connected + has a live CRTC) RandR outputs, in RandR's own
+// enumeration order - the list read_sunshine_output_index()'s value is
+// positionally matched against.
+struct MonitorRect {
+    int x = 0, y = 0, w = 0, h = 0;
+};
+
+bool get_primary_monitor_rect(::Display *display, ::Window root, MonitorRect &out) {
+    XRRScreenResources *res = XRRGetScreenResourcesCurrent(display, root);
+    if (!res) return false;
+    bool found = false;
+
+    RROutput primary = XRRGetOutputPrimary(display, root);
+    if (primary != None) {
+        XRROutputInfo *info = XRRGetOutputInfo(display, res, primary);
+        if (info && info->connection == RR_Connected && info->crtc != None) {
+            XRRCrtcInfo *crtc = XRRGetCrtcInfo(display, res, info->crtc);
+            if (crtc) {
+                out = {crtc->x, crtc->y, (int)crtc->width, (int)crtc->height};
+                found = true;
+                XRRFreeCrtcInfo(crtc);
+            }
+        }
+        if (info) XRRFreeOutputInfo(info);
+    }
+
+    if (!found) {
+        // No primary set (or it's disconnected/inactive) - fall back to the
+        // first active output found, still better than the whole desktop.
+        for (int i = 0; i < res->noutput && !found; i++) {
+            XRROutputInfo *info = XRRGetOutputInfo(display, res, res->outputs[i]);
+            if (info && info->connection == RR_Connected && info->crtc != None) {
+                XRRCrtcInfo *crtc = XRRGetCrtcInfo(display, res, info->crtc);
+                if (crtc) {
+                    out = {crtc->x, crtc->y, (int)crtc->width, (int)crtc->height};
+                    found = true;
+                    XRRFreeCrtcInfo(crtc);
+                }
+            }
+            if (info) XRRFreeOutputInfo(info);
+        }
+    }
+
+    XRRFreeScreenResources(res);
+    return found;
+}
+
+bool get_monitor_rect_by_index(::Display *display, ::Window root, int index, MonitorRect &out) {
+    XRRScreenResources *res = XRRGetScreenResourcesCurrent(display, root);
+    if (!res) return false;
+
+    int active_idx = 0;
+    bool found = false;
+    for (int i = 0; i < res->noutput; i++) {
+        XRROutputInfo *info = XRRGetOutputInfo(display, res, res->outputs[i]);
+        if (!info) continue;
+        if (info->connection == RR_Connected && info->crtc != None) {
+            if (active_idx == index) {
+                XRRCrtcInfo *crtc = XRRGetCrtcInfo(display, res, info->crtc);
+                if (crtc) {
+                    out = {crtc->x, crtc->y, (int)crtc->width, (int)crtc->height};
+                    found = true;
+                    XRRFreeCrtcInfo(crtc);
+                }
+                XRRFreeOutputInfo(info);
+                break;
+            }
+            active_idx++;
+        }
+        XRRFreeOutputInfo(info);
+    }
+
+    XRRFreeScreenResources(res);
+    return found;
+}
+
+} // namespace
+#endif // NIGHTFALL_HAS_XRANDR
+
+void X11Capture::select_capture_region(::Display *display, int screen, ::Window root,
+                                        int &out_x, int &out_y, int &out_w, int &out_h) {
+#ifdef NIGHTFALL_HAS_XRANDR
+    int sunshine_index = -1;
+    bool have_index = read_sunshine_output_index(sunshine_index);
+
+    MonitorRect rect;
+    if (have_index && sunshine_index >= 0 && get_monitor_rect_by_index(display, root, sunshine_index, rect)) {
+        NF_LOG("X11Capture", "Selected monitor by Sunshine output_name=%d: %dx%d+%d+%d",
+               sunshine_index, rect.w, rect.h, rect.x, rect.y);
+        out_x = rect.x; out_y = rect.y; out_w = rect.w; out_h = rect.h;
+        return;
+    }
+
+    if (get_primary_monitor_rect(display, root, rect)) {
+        NF_LOG("X11Capture", "Selected primary monitor (%s): %dx%d+%d+%d",
+               have_index ? "Sunshine output_name index out of range" : "no usable Sunshine config found",
+               rect.w, rect.h, rect.x, rect.y);
+        out_x = rect.x; out_y = rect.y; out_w = rect.w; out_h = rect.h;
+        return;
+    }
+
+    NF_LOGE("X11Capture", "RandR found no active outputs - falling back to full desktop capture");
+#else
+    (void)display; (void)screen; (void)root;
+    NF_LOG("X11Capture", "Built without RandR support - capturing full desktop (all monitors)");
+#endif
+    // Full-desktop fallback - matches the previous (pre-2026-08-20) behavior
+    // exactly, so an unusual/broken X setup never regresses to capturing
+    // nothing.
+    XWindowAttributes attrs;
+    XGetWindowAttributes(display, root, &attrs);
+    out_x = 0;
+    out_y = 0;
+    out_w = attrs.width;
+    out_h = attrs.height;
+}
 
 X11Capture::X11Capture() = default;
 
@@ -30,12 +211,14 @@ bool X11Capture::start() {
     screen_ = DefaultScreen(display_);
     Window root = RootWindow(display_, screen_);
 
-    XWindowAttributes attrs;
-    XGetWindowAttributes(display_, root, &attrs);
-    width_ = attrs.width;
-    height_ = attrs.height;
+    int sel_x = 0, sel_y = 0, sel_w = 0, sel_h = 0;
+    select_capture_region(display_, screen_, root, sel_x, sel_y, sel_w, sel_h);
+    x_offset_ = sel_x;
+    y_offset_ = sel_y;
+    width_ = sel_w;
+    height_ = sel_h;
 
-    NF_LOG("X11Capture", "Screen: %dx%d", width_, height_);
+    NF_LOG("X11Capture", "Capture region: %dx%d+%d+%d", width_, height_, x_offset_, y_offset_);
 
     if (width_ == 0 || height_ == 0) {
         NF_LOGE("X11Capture", "Invalid screen dimensions");
@@ -135,7 +318,7 @@ void X11Capture::capture_loop() {
     auto last_report = std::chrono::steady_clock::now();
 
     while (running_.load()) {
-        XShmGetImage(display_, root, image_, 0, 0, AllPlanes);
+        XShmGetImage(display_, root, image_, x_offset_, y_offset_, AllPlanes);
 
         XSync(display_, false);
 

--- a/addons/nightfall-stream/src/video/x11_capture.h
+++ b/addons/nightfall-stream/src/video/x11_capture.h
@@ -34,6 +34,13 @@ public:
 
     uint32_t get_width() const { return width_; }
     uint32_t get_height() const { return height_; }
+#ifdef NIGHTFALL_HAS_X11
+    int get_x_offset() const { return x_offset_; }
+    int get_y_offset() const { return y_offset_; }
+#else
+    int get_x_offset() const { return 0; }
+    int get_y_offset() const { return 0; }
+#endif
 
 private:
     void capture_loop();

--- a/addons/nightfall-stream/src/video/x11_capture.h
+++ b/addons/nightfall-stream/src/video/x11_capture.h
@@ -39,12 +39,24 @@ private:
     void capture_loop();
 
 #ifdef NIGHTFALL_HAS_X11
+    // Local-capture mode's monitor selection (2026-08-20) - see .cpp for the
+    // full reasoning. Determines (out_x, out_y, out_w, out_h) as an offset +
+    // size into the X11 root window, used both to size the SHM XImage in
+    // start() and as XShmGetImage()'s capture origin in capture_loop() (that
+    // call already supports an arbitrary sub-rectangle of the root window -
+    // this was previously always (0,0)+full-root-size, unconditionally
+    // capturing every connected monitor unioned together).
+    void select_capture_region(::Display *display, int screen, ::Window root,
+                                int &out_x, int &out_y, int &out_w, int &out_h);
+
     ::Display *display_ = nullptr;
     XShmSegmentInfo shm_info_;
     XImage *image_ = nullptr;
     int screen_ = 0;
     int damage_event_base_ = 0;
     int damage_error_base_ = 0;
+    int x_offset_ = 0;
+    int y_offset_ = 0;
 #endif
 
     std::thread worker_thread_;

--- a/build.sh
+++ b/build.sh
@@ -75,6 +75,16 @@ if [ "$PLATFORM" = "linux" ] || [ "$PLATFORM" = "appimage" ]; then
   SIZE=$(ls -lh "$LINUX_BINARY" | awk '{print $5}')
   echo "Assembled Linux binary ($SIZE)"
 
+  # Native AI-3D depth on Linux (MiDaS only, 2026-08-20) - midas_depth_engine.cpp
+  # resolves its model directory relative to the running executable's own path
+  # (OS::get_executable_path()'s base dir + "/depth_models"), NOT through
+  # Godot's res:///PCK - the PCK export above uses the Android preset as a
+  # headless-export workaround and never includes android/src/main/assets/.
+  # Same "loose files next to the binary" pattern as the .so/AAR copies below.
+  mkdir -p "$SCRIPT_DIR/depth_models"
+  cp "$SCRIPT_DIR/android/src/main/assets/midas-midas-v2-w8a8.tflite" "$SCRIPT_DIR/depth_models/"
+  cp "$SCRIPT_DIR/android/src/main/assets/midas-v21-small-192-int8.tflite" "$SCRIPT_DIR/depth_models/"
+
   rm -f "$SCRIPT_DIR/openxr_action_map.tres"
 
   if [ "$PLATFORM" = "appimage" ]; then
@@ -90,8 +100,10 @@ if [ "$PLATFORM" = "linux" ] || [ "$PLATFORM" = "appimage" ]; then
 
     mkdir -p "$APPDIR/usr/bin/addons/nightfall-stream/bin/linux"
     mkdir -p "$APPDIR/usr/bin/addons/godotopenxrvendors/.bin/linux/template_release/x86_64"
+    mkdir -p "$APPDIR/usr/bin/depth_models"
     cp "$SCRIPT_DIR/addons/nightfall-stream/bin/linux/libnightfall-stream.linux.template_release.x86_64.so" "$APPDIR/usr/bin/addons/nightfall-stream/bin/linux/"
     cp "$SCRIPT_DIR/addons/godotopenxrvendors/.bin/linux/template_release/x86_64/libgodotopenxrvendors.so" "$APPDIR/usr/bin/addons/godotopenxrvendors/.bin/linux/template_release/x86_64/"
+    cp "$SCRIPT_DIR/depth_models/"*.tflite "$APPDIR/usr/bin/depth_models/"
     cp "$SCRIPT_DIR/addons/godotopenxrvendors/plugin.gdextension" "$APPDIR/usr/bin/addons/godotopenxrvendors/"
     cp "$SCRIPT_DIR/nightfall-quest.desktop" "$APPDIR/nightfall-quest.desktop"
     cp "$SCRIPT_DIR/nightfall-quest.desktop" "$APPDIR/usr/share/applications/nightfall-quest.desktop"

--- a/docker-build-linux.sh
+++ b/docker-build-linux.sh
@@ -5,18 +5,44 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 IMAGE_NAME="nightfall-linux-builder"
 SOURCE_DIR="$SCRIPT_DIR/addons/nightfall-stream"
 OUTPUT_DIR="$SCRIPT_DIR/addons/nightfall-stream/bin/linux"
+# Native AI-3D depth on Linux (2026-08-20) vendors TFLite via CMake
+# FetchContent (see CMakeLists.txt) - a full clone of the tensorflow repo is
+# ~1GB+ and slow to fetch/build repeatedly. Bind-mounted directly AT
+# build/linux-release (not just FETCHCONTENT_BASE_DIR pointed elsewhere) so
+# the whole tree - including third-party deps TFLite fetches ITSELF via its
+# own "OverridableFetchContent" module (farmhash, gemmlowp, etc.) - persists
+# consistently across runs. A partial-cache attempt (only FETCHCONTENT_BASE_DIR
+# persisted, "rm -rf build/linux-release" every run) broke farmhash's
+# populate step: its subbuild driver files remembered a prior successful
+# fetch and tried a `git log`/update check against a checkout that had just
+# been wiped, since OverridableFetchContent checks sources out relative to
+# the build dir regardless of FETCHCONTENT_BASE_DIR. No `rm -rf` here
+# anymore - CMake/Ninja handle incremental reconfigure/rebuild fine, and this
+# also means our OWN code recompiles incrementally instead of from scratch
+# every time, not just TFLite's fetch step.
+#
+# NOTE: the container runs as root, so this directory ends up root-owned on
+# the host - `rm -rf` needs sudo, or clean it via a throwaway container, e.g.
+# `docker run --rm -v "$PWD/.linux-build-cache:/c" alpine rm -rf /c/*`.
+BUILD_CACHE_DIR="$SCRIPT_DIR/.linux-build-cache"
+mkdir -p "$BUILD_CACHE_DIR"
 
 docker build -t "$IMAGE_NAME" -f "$SCRIPT_DIR/Dockerfile.linux-build" "$SCRIPT_DIR"
 
 docker run --rm \
     -v "$SOURCE_DIR:/build/source:ro" \
     -v "$OUTPUT_DIR:/build/output" \
+    -v "$BUILD_CACHE_DIR:/build/work/build/linux-release" \
     "$IMAGE_NAME" \
     bash -c '
 set -e
-cp -r /build/source /build/work
+mkdir -p /build/work
+# Exclude "build/" from the copy - a stale local build/ dir on the host
+# source tree would otherwise land on top of (and corrupt) the persistent
+# build/linux-release cache mounted separately above. tar --exclude (not cp)
+# so this works whether or not the source happens to have one.
+(cd /build/source && tar --exclude="./build" -cf - .) | (cd /build/work && tar -xf -)
 cd /build/work
-rm -rf build/linux-release
 
 cmake --preset linux -DCMAKE_BUILD_TYPE=Release -B build/linux-release
 cmake --build build/linux-release

--- a/main.gd
+++ b/main.gd
@@ -1184,18 +1184,24 @@ func _init_modules():
 	add_child(controller_mapper)
 
 func _init_android_setup():
-	if OS.get_name() == "Android":
-		# Must run BEFORE _init_backgrounds_and_comp_layer() creates
-		# comp_viewport_left/right - depth_estimator's upsample/offset
-		# SubViewports (stereo_mode 5) produce the warp data those actually-
-		# displayed per-eye viewports consume every frame (via
-		# yuv_display.gdshader), and Godot updates SubViewports in scene-tree
-		# order, so the producer must be added to the tree first. (The
-		# upsample pass used to also depend on comp_viewport - the OPPOSITE
-		# direction - which was the real source of a stutter/double-image
-		# bug; that dependency was removed by having it decode YUV directly
-		# instead, see depth_upsample.gdshader.)
+	# AI-3D depth estimation is native (no JNI/JVM) on Linux as of 2026-08-20
+	# (see depth_bridge.cpp's NIGHTFALL_PLATFORM_LINUX branch/MidasDepthEngine,
+	# and settings_controller.gd's _ai_3d_supported()) - depth_estimator.setup()
+	# needs to run there too now, split out from the rest of this genuinely
+	# Android-only setup (controller models, hand fade materials, mouse
+	# capture - none of which apply to a desktop Linux client). Must run
+	# BEFORE _init_backgrounds_and_comp_layer() creates comp_viewport_left/
+	# right - depth_estimator's upsample/offset SubViewports (stereo_mode 5)
+	# produce the warp data those actually-displayed per-eye viewports
+	# consume every frame (via yuv_display.gdshader), and Godot updates
+	# SubViewports in scene-tree order, so the producer must be added to the
+	# tree first. (The upsample pass used to also depend on comp_viewport -
+	# the OPPOSITE direction - which was the real source of a stutter/
+	# double-image bug; that dependency was removed by having it decode YUV
+	# directly instead, see depth_upsample.gdshader.)
+	if OS.get_name() == "Android" or OS.get_name() == "Linux":
 		depth_estimator.setup()
+	if OS.get_name() == "Android":
 		Input.mouse_mode = Input.MOUSE_MODE_CAPTURED
 		_load_controller_models()
 		_prepare_fade_materials("right")

--- a/src/depth_estimator.gd
+++ b/src/depth_estimator.gd
@@ -131,7 +131,18 @@ func _init(owner: Node3D):
 	_platform = OS.get_name()
 
 func setup():
-	if _platform != "Android":
+	# AI-3D depth estimation is native (no JNI/JVM) on Linux as of 2026-08-20
+	# (see depth_bridge.cpp's NIGHTFALL_PLATFORM_LINUX branch/MidasDepthEngine) -
+	# same "Android or Linux" check as settings_controller.gd's
+	# _ai_3d_supported(). This guard used to be the ONLY thing gating AI-3D to
+	# Android; missing this second copy of it when Linux support was added
+	# left depth_viewport/depth_texture/upsample_viewport/offset_viewport
+	# etc. all null while the rest of the pipeline (now unlocked via
+	# settings_controller.gd) assumed setup() had actually run - a real
+	# crash (segfault) the moment AI-3D activated on Linux, since several
+	# call sites (_resize_warp_passes() in particular) don't null-check
+	# before using these.
+	if _platform != "Android" and _platform != "Linux":
 		main._log("[DEPTH] Depth estimation disabled on " + _platform)
 		return
 	depth_viewport = SubViewport.new()

--- a/src/screen_manager.gd
+++ b/src/screen_manager.gd
@@ -63,6 +63,26 @@ func resize_screen_to_aspect(stream_w: int, stream_h: int):
 		s.resize_to_aspect(content_w, content_h)
 	if main.comp_layer and main.comp_layer is OpenXRCompositionLayerQuad:
 		main.comp_layer.set_quad_size(main._mesh_size)
+	# GitHub issue #17 fix follow-up (found 2026-08-20): resize_to_aspect()
+	# above changes mesh_size (real content aspect, no longer a fixed 16:9
+	# "frame") but does NOT touch the composition-layer cylinder's own
+	# radius/central_angle (_comp_cyl_radius/_comp_cyl_central_angle,
+	# computed by update_cylinder_params() from mesh_size) - leaving them
+	# stale relative to the new mesh height. Those stale params drive BOTH
+	# the actual OpenXR cylinder layer's visual shape AND
+	# vr_screen.gd's hit_point_to_uv() click hit-testing (the comp.in_use
+	# branch re-projects the raycast onto a cylinder of THIS radius) -
+	# confirmed live: vertical click position was correct at screen center
+	# but increasingly wrong toward the top/bottom edges, exactly the
+	# "cylinder radius doesn't match the real geometry" signature. Every
+	# OTHER caller that resizes mesh_size already pairs it with an explicit
+	# update_cylinder_params() call (see settings_controller.gd's
+	# apply_screen_layout()) - stream_manager.gd's resize_stream_viewport()
+	# (the path actually active for local-capture-mode streaming) was the
+	# one missing it. Doing it here instead of at each call site means no
+	# future caller can miss this pairing again.
+	if main.comp.available:
+		main.comp.update_cylinder_params()
 
 func cycle_curvature():
 	main.curvature = (main.curvature + 1) % 3

--- a/src/settings_controller.gd
+++ b/src/settings_controller.gd
@@ -708,9 +708,9 @@ func apply_screen_layout(new_layout: ScreenLayout):
 	for s in main.screens.duplicate():
 		if not wanted_ids.has(s.monitor_id):
 			main.remove_screen(s.monitor_id)
+	# resize_screen_to_aspect() now calls update_cylinder_params() itself
+	# (2026-08-20) - no need to pair it here anymore.
 	main.screen_manager.resize_screen_to_aspect(new_layout.frame_size.x, new_layout.frame_size.y)
-	if main.comp.available:
-		main.comp.update_cylinder_params()
 	if main.comp.in_use and main.is_streaming:
 		main.comp.invalidate_yuv_cache()
 		main.comp.bind_yuv_textures()

--- a/src/settings_controller.gd
+++ b/src/settings_controller.gd
@@ -144,8 +144,17 @@ func cycle_sbs_mode():
 	if main.sbs_mode > 0 and main.screens.size() > 1:
 		main._ui_status_label.text = "SBS applies to primary screen only"
 
+# AI-3D depth estimation is native (no JNI/JVM) on Linux as of 2026-08-20
+# (see depth_bridge.cpp's NIGHTFALL_PLATFORM_LINUX branch / MidasDepthEngine) -
+# MiDaS-192/256 only for now, YOLO26/DA V2 aren't ported there yet (any other
+# model index falls back to MiDaS-256 on that platform, see
+# MidasDepthEngine::set_active_model()). A shared check here instead of
+# repeating "Android or Linux" three times below.
+func _ai_3d_supported() -> bool:
+	return OS.get_name() == "Android" or OS.get_name() == "Linux"
+
 func cycle_ai_3d_model():
-	if OS.get_name() != "Android":
+	if not _ai_3d_supported():
 		return
 	if main.sbs_mode > 0:
 		return
@@ -161,7 +170,7 @@ func cycle_ai_3d_model():
 	_schedule_ai_3d_commit()
 
 func cycle_ai_3d_quality():
-	if OS.get_name() != "Android":
+	if not _ai_3d_supported():
 		return
 	if main.sbs_mode > 0 or main.ai_3d_model == 0:
 		return
@@ -170,7 +179,7 @@ func cycle_ai_3d_quality():
 	_schedule_ai_3d_commit()
 
 func cycle_ai_3d_debug():
-	if OS.get_name() != "Android":
+	if not _ai_3d_supported():
 		return
 	if main.sbs_mode > 0 or main.ai_3d_model == 0:
 		return

--- a/src/stream_backend.gd
+++ b/src/stream_backend.gd
@@ -74,6 +74,11 @@ func set_local_capture_mode(enabled: bool):
 	if _v2 and _v2.has_method("set_local_capture_mode"):
 		_v2.set_local_capture_mode(enabled)
 
+func get_local_capture_region() -> Dictionary:
+	if _v2 and _v2.has_method("get_local_capture_region"):
+		return _v2.get_local_capture_region()
+	return {}
+
 func stop_play_stream():
 	if _v2:
 		_v2.stop_stream()

--- a/src/stream_manager.gd
+++ b/src/stream_manager.gd
@@ -40,7 +40,9 @@ func start_stream(host_id: int, app_id: int, forced_resolution: Vector2i = Vecto
 			ip = h_host.get("localaddress", "")
 			break
 
-	local_capture_mode = _is_local_host(ip)
+	local_capture_mode = _is_local_host(ip) and OS.get_environment("NIGHTFALL_DISABLE_LOCAL_CAPTURE") == ""
+	if OS.get_environment("NIGHTFALL_DISABLE_LOCAL_CAPTURE") != "" and _is_local_host(ip):
+		main._log("[STREAM] NIGHTFALL_DISABLE_LOCAL_CAPTURE set - forcing normal network decode path despite localhost")
 	if local_capture_mode:
 		main._log("[STREAM] Localhost detected! Enabling local capture mode (%s)" % ("Wayland" if OS.get_environment("WAYLAND_DISPLAY") else "X11"))
 		_b().set_local_capture_mode(true)
@@ -77,10 +79,24 @@ func start_stream(host_id: int, app_id: int, forced_resolution: Vector2i = Vecto
 	resize_stream_viewport(w, h)
 	var options = {}
 	if local_capture_mode:
-		options["width"] = 320
-		options["height"] = 240
-		options["fps"] = 10
-		options["bitrate"] = 2000
+		# Negotiated at the REAL resolution now, not a 320x240 dummy
+		# (2026-08-21 fix attempt) - theory: Sunshine sizes its OWN capture
+		# surface (and therefore what it scales incoming absolute mouse
+		# events against, via LiSendMousePositionEvent's refWidth/refHeight)
+		# off the NEGOTIATED stream dimensions, not off Nightfall's separate
+		# local X11 capture. A 320x240 negotiation would mean Sunshine's own
+		# internal mouse-scaling reference is 320x240 regardless of what
+		# ref we send - explaining a scale-correct-at-center-wrong-at-edges
+		# mismatch even though every client-side coordinate (uv, host_pt,
+		# ref itself) has been independently verified correct this session.
+		# Local capture never actually DISPLAYS this negotiated stream
+		# (real pixels come from x11_capture.cpp's zero-copy grab instead),
+		# so full resolution costs nothing but negotiation/decode overhead -
+		# fps/bitrate stay minimal since the decoded frames are discarded.
+		options["width"] = w
+		options["height"] = h
+		options["fps"] = 5
+		options["bitrate"] = 500
 	else:
 		options["width"] = w
 		options["height"] = h
@@ -186,10 +202,12 @@ func _on_v2_launch_response(response: Dictionary):
 
 	var stream_config = {}
 	if local_capture_mode:
-		stream_config["width"] = 320
-		stream_config["height"] = 240
-		stream_config["fps"] = 10
-		stream_config["bitrate"] = 2000
+		# Real resolution, not a 320x240 dummy - see the matching comment in
+		# start_stream()'s options block for the full reasoning.
+		stream_config["width"] = w
+		stream_config["height"] = h
+		stream_config["fps"] = 5
+		stream_config["bitrate"] = 500
 	else:
 		stream_config["width"] = w
 		stream_config["height"] = h
@@ -490,11 +508,31 @@ func update_stats():
 	var new_frame = _b().consume_new_frame()
 	var vw = _b().get_video_width()
 	var vh = _b().get_video_height()
-	if vw == 0 or vh == 0:
-		return
-	var cur_size = main.stream_viewport.size
-	if cur_size.x != vw or cur_size.y != vh:
-		resize_stream_viewport(vw, vh)
+	# Local-capture mode (2026-08-21 fix) - the negotiated RTSP video stream
+	# in this mode is a throwaway 320x240 dummy (see start_stream()'s
+	# options block below); get_video_width()/height() read the DECODER's
+	# dims, which reflect that dummy stream, not the real X11-captured
+	# monitor. Relying on vw/vh here (as the normal network path correctly
+	# does) meant layout.frame_size/host_ref() never matched what was
+	# actually captured/shown, sending clicks scaled against the wrong
+	# frame size (confirmed live: [CAPTURE-GT] showed layout.frame_size
+	# stuck at host_resolution/native_resolution defaults while the real
+	# X11 capture was a different resolution entirely). Poll the real
+	# capture region instead and reconcile against THAT.
+	if local_capture_mode:
+		var region = _b().get_local_capture_region()
+		var rw = int(region.get("width", 0))
+		var rh = int(region.get("height", 0))
+		if rw > 0 and rh > 0:
+			var cur_local = main.stream_viewport.size
+			if cur_local.x != rw or cur_local.y != rh:
+				resize_stream_viewport(rw, rh)
+	else:
+		if vw == 0 or vh == 0:
+			return
+		var cur_size = main.stream_viewport.size
+		if cur_size.x != vw or cur_size.y != vh:
+			resize_stream_viewport(vw, vh)
 	var hw = "HW" if _b().is_hw_decode() else "SW"
 	var ip = main.get_node("%IPInput").text
 	var ip_display = ip if not ip.is_empty() else "?"

--- a/src/vr_screen.gd
+++ b/src/vr_screen.gd
@@ -475,8 +475,23 @@ func hit_point_to_uv(hit_point: Vector3) -> Vector2:
 			var t = t1 if t1 > 0.001 else t2
 			if t > 0.0:
 				var hit_world = cam_pos + ray_dir * t
-				var hit_local = to_local(hit_world)
-				uv_y = clampf((ms.y * 0.5 - hit_local.y) / ms.y, 0.0, 1.0)
+				# uv_y is deliberately NOT reprojected here (unlike uv_x) -
+				# curvature only bends the screen horizontally, so the
+				# mesh's vertical extent is exactly mesh_size.y regardless
+				# of cylinder radius. Re-deriving Y from the ray-cylinder
+				# intersection walks the ray out to a DIFFERENT point along
+				# its direction using _comp_cyl_radius (maintained on its
+				# own update schedule via update_cylinder_params(), not
+				# necessarily in sync with the radius the collision mesh
+				# was actually built with in apply_curvature()) - any drift
+				# between those two radii pushed the reprojected Y away
+				# from the raw raycast hit, growing worse toward the edges
+				# (confirmed live, 2026-08-21: the in-VR pointer reticle,
+				# anchored to the raw hit_point/local_pos.y computed at the
+				# top of this function, renders in the visually correct
+				# spot; only the value SENT to the host was wrong). The uv_y
+				# computed at the top of this function from the real,
+				# visually-correct raycast hit is used as-is.
 				var hit_cyl = hit_world - _comp_cyl_center
 				var hit_right = hit_cyl.dot(screen_right)
 				var hit_fwd = hit_cyl.dot(screen_forward)


### PR DESCRIPTION
## Summary

AI-3D depth estimation was previously Android-only - `depth_bridge.cpp` stubbed everything out on Linux via `#ifdef __ANDROID__`. Since we already confirmed even Android's path is just CPU/XNNPACK (no vendor NNAPI HAL on Quest, no real hardware acceleration), a native CPU-only Linux implementation isn't a capability downgrade.

- **New `MidasDepthEngine`** (`addons/nightfall-stream/src/video/`) - direct C++ port of `DepthEstimator.java`'s MiDaS-192/256 logic (quantization params read from each model's own tensor metadata, `robustRange`/`postProcess`/`temporalSmooth` ported verbatim), same async single-inference-in-flight policy. YOLO26/DA V2 aren't ported yet - unrecognized model indices fall back to MiDaS-256, matching Android's own fallback behavior.
- **TFLite vendored via CMake `FetchContent`** (pinned to `v2.16.1`, matching the Android Gradle dependency) - no usable prebuilt exists for Linux (vcpkg only has the full Bazel-built `tensorflow`/`tensorflow-cc`, which takes hours to build from source).
- **Model files ship as loose files** next to the binary (`depth_models/`, populated by `build.sh`) rather than through Godot's PCK, since the Linux PCK export never includes `android/src/main/assets/`.
- **Found and fixed three separate hardcoded Android-only gates** that blocked this end-to-end even after the above was wired up: `settings_controller.gd`'s `cycle_ai_3d_model/_quality/_debug`, `depth_estimator.gd`'s `setup()`, and `main.gd`'s `_init_android_setup()` (which only called `depth_estimator.setup()` inside its own Android-only block). Missing the latter two meant AI-3D could be *toggled* on, but `depth_viewport`/`depth_texture`/`upsample_viewport`/`offset_viewport` were never created - a real segfault in Godot's own engine code (not our GDExtension) the instant AI-3D activated. Root-caused via a standalone `MidasDepthEngine` test harness (ruled out the engine itself, ran 6 clean model-switch cycles) plus a debug-symbol build run under `gdb` (crash addresses matched the stripped release build exactly, pointing at Godot engine code rather than our .so).
- **Also fixes local-capture "zero-copy" mode** (same-machine Sunshine) always grabbing the WHOLE X11 desktop instead of just the monitor Sunshine is configured to stream. Best-effort: reads Sunshine's own config (checking native + Flatpak install paths) for its `output_name` (an NvFBC index) and matches it positionally against RandR's active-output list; falls back to the RandR primary monitor if that fails, and to the old full-desktop behavior if RandR itself is unavailable.

## Test plan

- [x] `godot --headless --check-only` exits 0
- [x] Docker build succeeds cleanly (0 errors), incremental rebuilds ~20s thanks to a persistent build-dir cache added to `docker-build-linux.sh`
- [x] Live-tested end-to-end against a real local Sunshine instance: monitor selection confirmed correct (single monitor captured, not the unioned multi-monitor desktop), AI-3D toggle works, MiDaS-192/256 switching confirmed stable (no crash) after the three Android-only gates were fixed
- [ ] YOLO26/DA V2 on Linux - explicitly out of scope for this PR, follow-up work