### PR TITLE
Composite hand indicator, Quest 2 tuning, AI-3D model-switch fix

### DIFF
--- a/addons/nightfall-stream/src/video/depth_bridge.cpp
+++ b/addons/nightfall-stream/src/video/depth_bridge.cpp
@@ -348,6 +348,38 @@ float DepthBridge::get_depth_last_inference_hz() {
 #endif
 }
 
+// Headset model string (2026-08-27) - see GodotApp.java's getDeviceModel()
+// comment. Same JNI call pattern as the getters above; Linux/other
+// platforms return an empty string, which callers treat the same as "not a
+// recognized Quest 2" (settings_controller.gd only special-cases a match).
+String DepthBridge::get_device_model() {
+#ifdef __ANDROID__
+    JNIEnv *env = get_jni_env();
+    if (!env) return String();
+
+    jclass app_class = env->FindClass("com/godot/game/GodotApp");
+    if (!app_class) return String();
+
+    jmethodID method = env->GetStaticMethodID(app_class, "getDeviceModel", "()Ljava/lang/String;");
+    if (!method) {
+        env->DeleteLocalRef(app_class);
+        return String();
+    }
+
+    jstring jresult = (jstring)env->CallStaticObjectMethod(app_class, method);
+    env->DeleteLocalRef(app_class);
+    if (!jresult) return String();
+
+    const char *chars = env->GetStringUTFChars(jresult, nullptr);
+    String result = String::utf8(chars);
+    env->ReleaseStringUTFChars(jresult, chars);
+    env->DeleteLocalRef(jresult);
+    return result;
+#else
+    return String();
+#endif
+}
+
 void DepthBridge::_bind_methods() {
     ClassDB::bind_method(D_METHOD("submit_depth_frame", "frame_data", "width", "height"), &DepthBridge::submit_depth_frame);
     ClassDB::bind_method(D_METHOD("get_depth_map"), &DepthBridge::get_depth_map);
@@ -359,4 +391,5 @@ void DepthBridge::_bind_methods() {
     ClassDB::bind_method(D_METHOD("get_depth_model_size"), &DepthBridge::get_depth_model_size);
     ClassDB::bind_method(D_METHOD("get_depth_last_inference_ms"), &DepthBridge::get_depth_last_inference_ms);
     ClassDB::bind_method(D_METHOD("get_depth_last_inference_hz"), &DepthBridge::get_depth_last_inference_hz);
+    ClassDB::bind_method(D_METHOD("get_device_model"), &DepthBridge::get_device_model);
 }

--- a/addons/nightfall-stream/src/video/depth_bridge.h
+++ b/addons/nightfall-stream/src/video/depth_bridge.h
@@ -39,6 +39,7 @@ public:
     int get_depth_model_size();
     float get_depth_last_inference_ms();
     float get_depth_last_inference_hz();
+    String get_device_model();
 
 protected:
     static void _bind_methods();

--- a/android/src/main/java/com/godot/game/GodotApp.java
+++ b/android/src/main/java/com/godot/game/GodotApp.java
@@ -130,6 +130,21 @@ public class GodotApp extends GodotActivity {
 		return depthEstimator != null ? depthEstimator.getLastInferenceHz() : 0f;
 	}
 
+	// Headset device codename (e.g. "hollywood" for Quest 2, "eureka" for
+	// Quest 3) - used by settings_controller.gd to pick a per-device AI-3D
+	// Auto table and resolution ceiling (2026-08-27, following a Quest 2
+	// user report that AI-3D tanks performance there - the existing
+	// AUTO_TABLE was hand-tuned entirely on Quest 3/3s hardware).
+	// Build.MODEL is USELESS here - confirmed on a real Quest 3 that it
+	// returns the generic "Quest" regardless of generation (likely a Meta
+	// compatibility shim), not the marketing name. Build.DEVICE returns the
+	// real internal codename instead (matches "ro.product.device"/
+	// "ro.hardware" at the system-property level, confirmed "eureka" on
+	// that same Quest 3) and is what's actually distinct per generation.
+	public static String getDeviceModel() {
+		return android.os.Build.DEVICE;
+	}
+
 	// One-off diagnostic for the H.264/HEVC hardware decoder dimension limits on this
 	// device - queried directly from the platform instead of inferred from trial and error.
 	public static String getCodecCapabilitiesInfo() {

--- a/main.gd
+++ b/main.gd
@@ -87,20 +87,22 @@ var _startup_ready: bool = false
 var _is_using_hands: bool = false
 var tracking_mode: int = 0
 var tracking_labels: Array = ["Off", "Hands"]
-var right_hand_visual: Node3D = null
-var left_hand_visual: Node3D = null
 
 # OS/runtime controller render models (2026-08-25, docs/gles-quest-projectionless-plan.md's
 # "Controller and hand experiment" section) - OpenXRFbRenderModel wraps
 # XR_FB_render_model, letting the runtime hand us its own real controller
 # mesh instead of the bundled MetaQuestTouchPlus FBX (_load_controller_models()
-# below, which stays as the fallback). Default OFF ("keep this behind a
-# runtime/debug flag until tested" - unlike the DEBUG_COMP_* flags earlier
-# this session, which default true because they're already confirmed
-# working, this one hasn't been tested on-device at all yet). Deliberately
-# scoped to normal (mesh) projection mode only, per the plan - projectionless/
-# composition mode would need a full 3D-in-composition-layer controller
-# renderer, explicitly called out as out of scope for this first pass.
+# below, which stays as the fallback, and is no longer even bundled in the
+# Android export - see export_presets.cfg). Default OFF. Tried routing it
+# through a composition-space 3D capture (2026-08-27, same technique as the
+# hand-skeleton indicator that used to live below) - pulled back out along
+# with that whole approach: rendering a real 3D scene into an offscreen
+# viewport every frame was too expensive even throttled to 14fps (see the
+# composite-only hand indicator that replaced it), and there's every reason
+# to expect the same cost for controllers. Back to its original scope:
+# normal (mesh) projection mode only - projectionless/composition mode
+# would need a genuinely cheap 3D-in-composition-layer renderer, which this
+# isn't, so it stays out of scope until one exists.
 const DEBUG_RENDER_MODEL_CONTROLLERS := false
 var right_render_model: Node3D = null
 var left_render_model: Node3D = null
@@ -202,6 +204,23 @@ var resolution_scale_options: Array = RESOLUTION_PRESETS
 # Defaults false (the old fixed-list picker) so a host that hasn't been probed
 # yet - or a probe that's still in flight - never shows a percentage of a
 # guess as if it meant something.
+# Detected once at startup via stream_backend.get_device_model() (Android's
+# Build.MODEL, read through DepthBridge's JNI bridge - see GodotApp.java's
+# getDeviceModel()). Quest 2's Snapdragon XR2 Gen 1 GPU benchmarks at
+# roughly 2-2.5x slower than Quest 3/3s's XR2 Gen 2 (Meta's own published
+# figures), and our AI-3D depth inference runs on the GLES GPU delegate -
+# the same GPU used for rendering, not the (much bigger, but NNAPI-gated
+# and unavailable to us) NPU gap - so the existing AUTO_TABLE (hand-tuned
+# entirely on Quest 3/3s) is a poor fit there. Added 2026-08-27 after a
+# Quest 2 user reported AI-3D tanking performance; see settings_controller.
+# gd's QUEST2_AUTO_TABLE and main.gd's QUEST2_MAX_RESOLUTION.
+var device_is_quest2: bool = false
+# See device_is_quest2's comment. Quest 2's own per-eye display resolution
+# (~1832x1920) is already below Quest 3's, so there's no real benefit
+# requesting more than this regardless of AI-3D state - applied in
+# compute_requested_resolution() as a hard ceiling before any other cap.
+const QUEST2_MAX_RESOLUTION := Vector2i(1920, 1080)
+
 var is_polaris_host: bool = false
 # The pre-percentage fixed-resolution picker, used for any non-Polaris host
 # (see is_polaris_host above) - the user picks what they actually want
@@ -300,6 +319,7 @@ const DEBUG_COMP_LASER := true
 const DEBUG_COMP_GRAB_BAR := true
 const DEBUG_COMP_CORNERS := true
 const DEBUG_COMP_MARKER := true
+const DEBUG_COMP_HANDS := true
 
 # Composition-space controller ray indicators (2026-08-24, GLES projectionless
 # polish) - projectionless mode (submit_projection_layer=false) never renders
@@ -324,6 +344,45 @@ var comp_marker_left: Node3D = null
 var comp_marker_right_circle: ColorRect = null
 var comp_marker_left_circle: ColorRect = null
 const MARKER_IDLE_ALPHA := 0.16
+
+# Composition-space hand indicator (2026-08-27) - see _update_hand_indicator_
+# layers(). First attempt at this was a full 25-joint/24-bone skeleton
+# rendered as a real 3D scene into an offscreen SubViewport every frame
+# (same technique as comp_bg_capture_viewport) - reported as "tanking
+# performance" even throttled to 14fps, so pulled back out entirely. This
+# is deliberately as cheap as the controller markers just below: a single
+# flat triangle icon per hand (src/shaders/inverted_triangle.gdshader), no
+# offscreen 3D scene/camera at all - but unlike the markers, the quad is NOT
+# simply billboarded to the camera and the triangle is NOT a fixed shape.
+# Both are driven live from three real joints (WRIST, and the INDEX/PINKY
+# PHALANX_PROXIMAL joints as the two visible "knuckle" points - NOT the
+# METACARPAL joints, which sit near the wrist/thumb-base and read as the
+# wrong knuckle entirely, confirmed on-device) every frame - see
+# _update_one_hand_indicator(). comp_hand_right_triangle/left_triangle are
+# the ColorRect nodes whose ShaderMaterial gets the live point_a/b/c
+# uniforms; comp_hand_right/left are the composition quads themselves.
+var comp_hand_right: Node3D = null
+var comp_hand_left: Node3D = null
+var comp_hand_right_triangle: ColorRect = null
+var comp_hand_left_triangle: ColorRect = null
+# Fixed quad size (2026-08-27) - _update_one_hand_indicator() only ever
+# repositions/reorients the quad, never resizes it - simpler than
+# continuously resizing, and quad_size changes are exactly what
+# _set_comp_quad_hidden() already (ab)uses for hide/show, so keeping it
+# fixed also avoids any interaction between that and a "real" dynamic size.
+# 0.32m, not the original 0.14m (2026-08-27 fix) - the UV projection
+# divides the real wrist-to-knuckle distance by this value directly (see
+# _update_one_hand_indicator()), so it needs to be at least DOUBLE the
+# largest real joint distance from the wrist for that distance to land
+# within the quad's UV [0,1] range at all. A real wrist-to-index-knuckle
+# distance is commonly 8-11cm, comfortably exceeding 0.14's own half-width
+# of 7cm - confirmed as the actual cause of "half the triangle missing"
+# (the index vertex was being clipped off the edge of the quad). 0.32
+# gives a 16cm half-width, safely covering real hands with margin; making
+# the quad physically bigger doesn't make the visible triangle any bigger -
+# everything outside the triangle is fully transparent - it just gives the
+# real joint-driven shape room to not clip.
+const HAND_INDICATOR_SIZE := 0.32
 
 # Composition-space environment-background replacement (2026-08-24,
 # GLES projectionless polish) - the ambient particle backgrounds
@@ -648,6 +707,19 @@ func compute_requested_resolution(apply_midas_cap: bool = true) -> Vector2i:
 		if scale < 1.0:
 			w = int(w * scale)
 			h = int(h * scale)
+	# Quest 2 hard resolution ceiling (2026-08-27, see device_is_quest2's own
+	# comment) - unconditional (not gated on apply_midas_cap, unlike the
+	# AI-3D cap_px block below) since this reflects real hardware/display
+	# limits, not an AI-3D-specific tradeoff: Quest 2's own per-eye panel
+	# resolution is already below Quest 3's, so there's no benefit
+	# requesting more than this regardless of AI-3D state. Applied BEFORE
+	# the AI-3D cap block, so get_auto_selection()'s own classification
+	# (which reads this same function with apply_midas_cap=false) always
+	# sees the already-1080p-capped value too.
+	if device_is_quest2 and w * h > QUEST2_MAX_RESOLUTION.x * QUEST2_MAX_RESOLUTION.y:
+		var quest2_scale = sqrt(float(QUEST2_MAX_RESOLUTION.x * QUEST2_MAX_RESOLUTION.y) / float(w * h))
+		w = int(w * quest2_scale)
+		h = int(h * quest2_scale)
 	# MiDaS-Fast only - see MIDAS_RES_CAP_ENABLED's comment above. Keyed off
 	# the actually-active stereo mode (accounts for sbs_mode overriding
 	# ai_3d_speed/model/debug, same as settings_controller.get_stereo_mode()
@@ -1581,9 +1653,6 @@ func _init_android_setup():
 			left_hand_raycast.name = "LeftHandRayCast"
 			left_hand.add_child(left_hand_raycast)
 
-	right_hand_visual = _create_hand_visualizer(false)
-	left_hand_visual = _create_hand_visualizer(true)
-
 func _init_ui():
 	virtual_keyboard = VirtualKeyboard.new(self)
 	add_child(virtual_keyboard)
@@ -1927,6 +1996,13 @@ func _init_stream_backend():
 	stream_backend = StreamBackend.new(v2_node)
 	stream_backend.set_config_manager(config_mgr)
 	stream_backend.set_computer_manager(comp_mgr)
+	if OS.get_name() == "Android":
+		# "hollywood" (Quest 2's real device codename) - Build.MODEL itself is
+		# useless (confirmed on a real Quest 3 to just return "Quest", not the
+		# generation), see GodotApp.java's getDeviceModel() comment.
+		var device_codename = stream_backend.get_device_model()
+		device_is_quest2 = device_codename.to_lower() == "hollywood"
+		_log("[DEVICE] Build.DEVICE='%s' device_is_quest2=%s" % [device_codename, str(device_is_quest2)])
 	_client_codec_support = stream_backend.probe_all_video_formats()
 	_log("[CODEC] Client support: h264=%s hevc=%s av1=%s raw=%s" % [
 		str(_client_codec_support.get("h264", false)),
@@ -2179,6 +2255,7 @@ func _process(delta):
 	_update_cursor_layer()
 	_update_laser_layers()
 	_update_marker_layers(delta)
+	_update_hand_indicator_layers()
 	_update_grab_bar_layers()
 	_sync_comp_background()
 
@@ -2330,13 +2407,8 @@ func _process_hand_tracking(_delta):
 		var left_tracker = XRServer.get_tracker("/user/hand_tracker/left")
 		if right_tracker:
 			_update_hand_tracker_transform(right_hand, right_tracker)
-			_update_hand_visualizer(right_hand_visual, right_tracker)
 		if left_tracker:
 			_update_hand_tracker_transform(left_hand, left_tracker)
-			_update_hand_visualizer(left_hand_visual, left_tracker)
-	else:
-		if right_hand_visual: right_hand_visual.visible = false
-		if left_hand_visual: left_hand_visual.visible = false
 	if Engine.get_frames_drawn() % 90 == 0:
 		_log("[INPUT-DEBUG] HandsActive: %s, RightHand tracker: %s, pos: %s, rot: %s" % [
 			str(_is_using_hands),
@@ -2886,86 +2958,111 @@ func _create_snow():
 func _create_data():
 	bg_manager._create_data()
 
-func _create_hand_visualizer(is_left: bool) -> Node3D:
-	var hand_vis = Node3D.new()
-	hand_vis.name = "LeftHandVisual" if is_left else "RightHandVisual"
-	
-	var mat = StandardMaterial3D.new()
-	mat.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
-	mat.albedo_color = Color(0.3, 0.7, 1.0, 0.3) # soft semi-transparent blue
-	mat.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
-	mat.no_depth_test = true
-	mat.render_priority = 100
-	
-	var palm_mesh = MeshInstance3D.new()
-	palm_mesh.name = "Palm"
-	var sphere = SphereMesh.new()
-	sphere.radius = 0.04
-	sphere.height = 0.06
-	palm_mesh.mesh = sphere
-	palm_mesh.material_override = mat
-	hand_vis.add_child(palm_mesh)
-	
-	var index_mesh = MeshInstance3D.new()
-	index_mesh.name = "Index"
-	var cap = CylinderMesh.new()
-	cap.top_radius = 0.008
-	cap.bottom_radius = 0.008
-	cap.height = 1.0 # scaled dynamically
-	index_mesh.mesh = cap
-	index_mesh.material_override = mat
-	hand_vis.add_child(index_mesh)
-	
-	hand_vis.visible = false
-	xr_origin.add_child(hand_vis)
-	return hand_vis
+# Composite-only hand indicators (2026-08-27, replacing the expensive
+# viewport-capture hand skeleton) - same cost profile as
+# _update_one_marker_layer() (see above): a small procedurally-shaded quad,
+# no offscreen 3D scene or capture camera involved at all. Unlike the
+# markers, though, the quad's own orientation and the triangle's three
+# shader-uniform vertices are both recomputed live every frame from three
+# real joints (WRIST, INDEX/PINKY PHALANX_PROXIMAL knuckle joints) - see
+# _update_one_hand_indicator().
+func _update_hand_indicator_layers():
+	if not comp_hand_right and not comp_hand_left:
+		return
+	if not DEBUG_COMP_HANDS or not comp.in_use or not is_xr_active or not _is_using_hands:
+		_set_comp_quad_hidden(comp_hand_right, true)
+		_set_comp_quad_hidden(comp_hand_left, true)
+		return
+	var right_tracker = XRServer.get_tracker("/user/hand_tracker/right")
+	var left_tracker = XRServer.get_tracker("/user/hand_tracker/left")
+	_update_one_hand_indicator(comp_hand_right, comp_hand_right_triangle, right_tracker)
+	_update_one_hand_indicator(comp_hand_left, comp_hand_left_triangle, left_tracker)
 
-func _update_hand_visualizer(hand_vis: Node3D, tracker: XRHandTracker):
-	if not hand_vis or not tracker:
+# Builds the quad's plane directly from the hand's own three joints, rather
+# than billboarding to the camera like the markers/laser do - this is what
+# makes the triangle actually track hand orientation/shape in real time
+# instead of just following wrist position with a fixed icon.
+func _update_one_hand_indicator(layer: Node3D, triangle: ColorRect, tracker: XRHandTracker):
+	if not layer or not triangle:
 		return
-		
-	var palm_has = (tracker.get_hand_joint_flags(XRHandTracker.HAND_JOINT_PALM) & 8) != 0
-	var knuckle_has = (tracker.get_hand_joint_flags(XRHandTracker.HAND_JOINT_INDEX_FINGER_METACARPAL) & 8) != 0
-	var tip_has = (tracker.get_hand_joint_flags(XRHandTracker.HAND_JOINT_INDEX_FINGER_TIP) & 8) != 0
-	
-	if not palm_has and not knuckle_has:
-		hand_vis.visible = false
+	if not tracker or not (tracker is XRHandTracker):
+		_set_comp_quad_hidden(layer, true)
 		return
-		
-	hand_vis.visible = true
-	
-	var palm_mesh = hand_vis.get_node("Palm")
-	if palm_has:
-		palm_mesh.transform = tracker.get_hand_joint_transform(XRHandTracker.HAND_JOINT_PALM)
-		palm_mesh.visible = true
-	else:
-		palm_mesh.visible = false
-		
-	var index_mesh = hand_vis.get_node("Index")
-	if knuckle_has and tip_has:
-		var knuckle_pos = tracker.get_hand_joint_transform(XRHandTracker.HAND_JOINT_INDEX_FINGER_METACARPAL).origin
-		var tip_pos = tracker.get_hand_joint_transform(XRHandTracker.HAND_JOINT_INDEX_FINGER_TIP).origin
-		
-		var delta = tip_pos - knuckle_pos
-		var dist = delta.length()
-		if dist > 0.001:
-			var center = knuckle_pos + delta * 0.5
-			var dir = delta.normalized()
-			
-			var up = dir
-			var right = dir.cross(Vector3.UP).normalized()
-			if right.length_squared() < 0.01:
-				right = dir.cross(Vector3.FORWARD).normalized()
-			var fwd = right.cross(up).normalized()
-			
-			var basis = Basis(right, up, fwd)
-			index_mesh.transform = Transform3D(basis, center)
-			index_mesh.scale = Vector3(1, dist, 1) # scale height
-			index_mesh.visible = true
-		else:
-			index_mesh.visible = false
-	else:
-		index_mesh.visible = false
+	const TRACKED := XRHandTracker.HAND_JOINT_FLAG_POSITION_TRACKED
+	var wrist_ok = (tracker.get_hand_joint_flags(XRHandTracker.HAND_JOINT_WRIST) & TRACKED) != 0
+	var index_ok = (tracker.get_hand_joint_flags(XRHandTracker.HAND_JOINT_INDEX_FINGER_PHALANX_PROXIMAL) & TRACKED) != 0
+	var pinky_ok = (tracker.get_hand_joint_flags(XRHandTracker.HAND_JOINT_PINKY_FINGER_PHALANX_PROXIMAL) & TRACKED) != 0
+	if not (wrist_ok and index_ok and pinky_ok):
+		_set_comp_quad_hidden(layer, true)
+		return
+
+	var wrist_pos = tracker.get_hand_joint_transform(XRHandTracker.HAND_JOINT_WRIST).origin
+	var index_pos = tracker.get_hand_joint_transform(XRHandTracker.HAND_JOINT_INDEX_FINGER_PHALANX_PROXIMAL).origin
+	var pinky_pos = tracker.get_hand_joint_transform(XRHandTracker.HAND_JOINT_PINKY_FINGER_PHALANX_PROXIMAL).origin
+
+	var to_index = index_pos - wrist_pos
+	var to_pinky = pinky_pos - wrist_pos
+	if to_index.length_squared() < 0.0001 or to_pinky.length_squared() < 0.0001:
+		_set_comp_quad_hidden(layer, true)
+		return
+
+	# Orthonormal basis for the hand's own plane (Gram-Schmidt from the two
+	# knuckle directions), not the camera - x_axis/y_axis span the plane the
+	# triangle is drawn in, z_axis is its face normal. Degeneracy check is
+	# done on NORMALIZED directions (2026-08-27, was on the raw cross
+	# product before, which is |to_index|*|to_pinky|*sin(angle) - since
+	# metacarpal joints sit only a few cm from the wrist, that magnitude is
+	# tiny even at a healthy ~30 degree real hand spread, so the raw check
+	# rejected ordinary poses every single frame - "not seeing the triangle
+	# at all" turned out to be exactly this, confirmed via [HANDIND] logs
+	# showing "degenerate cross product" on every frame with real tracked
+	# joints). The normalized cross product is just sin(angle), scale-
+	# independent - 0.0004 here is sin(angle) < 0.02, i.e. angle < ~1.1
+	# degrees, only rejecting genuinely near-collinear moments.
+	var x_axis = to_index.normalized()
+	var raw_normal = x_axis.cross(to_pinky.normalized())
+	if raw_normal.length_squared() < 0.0004:
+		_set_comp_quad_hidden(layer, true) # index/pinky/wrist briefly collinear
+		return
+	raw_normal = raw_normal.normalized()
+	# The compositor renders this quad single-sided - pick whichever normal
+	# direction faces the viewer (palm-up vs palm-down) BEFORE deriving
+	# y_axis from it (2026-08-27 fix - previously flipped z_axis/y_axis
+	# AFTER y_axis was already built from the other sign, which could leave
+	# the projection below effectively mirrored depending on viewing angle:
+	# reported as the pinky point reading as the thumb knuckle instead.
+	# Deciding the final sign first and deriving y_axis from THAT removes
+	# the possibility entirely, at the cost of the triangle occasionally
+	# appearing mirrored left/right rather than anatomically exact when the
+	# hand rotates - cheap and correct often enough for an indicator, not a
+	# concern for a real hand mesh).
+	var z_axis = raw_normal if raw_normal.dot(xr_camera.global_position - wrist_pos) >= 0.0 else -raw_normal
+	var y_axis = z_axis.cross(x_axis).normalized()
+	x_axis = y_axis.cross(z_axis) # re-orthogonalize against the final y_axis
+
+	layer.global_transform = Transform3D(Basis(x_axis, y_axis, z_axis), wrist_pos)
+	layer.set_quad_size(Vector2(HAND_INDICATOR_SIZE, HAND_INDICATOR_SIZE))
+	layer.visible = true
+
+	# Project each joint into the quad's own local 2D plane (wrist is the
+	# origin by construction) and convert to UV [0,1] for the shader -
+	# inverted_triangle.gdshader's point_a/b/c. Confirmed on-device
+	# (2026-08-27) that the V-axis sign here reads backwards relative to
+	# y_axis's real 3D direction - pinky consistently landed mirrored to
+	# the opposite side (reading as the thumb knuckle). Negated ONLY for
+	# this 2D projection, not for y_axis itself (still used un-negated for
+	# the quad's actual 3D orientation below/above) - index sits exactly on
+	# the V=0.5 centerline by construction (to_index has zero y_axis
+	# component), so this only ever affects pinky's rendered side, not the
+	# quad's real-world placement.
+	var half = HAND_INDICATOR_SIZE
+	var wrist_uv = Vector2(0.5, 0.5)
+	var index_uv = Vector2(x_axis.dot(to_index), -y_axis.dot(to_index)) / half + wrist_uv
+	var pinky_uv = Vector2(x_axis.dot(to_pinky), -y_axis.dot(to_pinky)) / half + wrist_uv
+	var mat: ShaderMaterial = triangle.material
+	mat.set_shader_parameter("point_a", index_uv)
+	mat.set_shader_parameter("point_b", wrist_uv)
+	mat.set_shader_parameter("point_c", pinky_uv)
 
 func _update_hand_tracker_transform(hand_node: XRController3D, tracker: XRHandTracker):
 	var wrist_ok = (tracker.get_hand_joint_flags(XRHandTracker.HAND_JOINT_WRIST) & 8) != 0

--- a/project.godot
+++ b/project.godot
@@ -46,4 +46,4 @@ openxr/environment_blend_mode=2
 openxr/extensions/hand_tracking=true
 shaders/enabled=true
 openxr/extensions/meta/passthrough=true
-openxr/extensions/meta/render_model=false
+openxr/extensions/meta/render_model=true

--- a/src/composition_layer_manager.gd
+++ b/src/composition_layer_manager.gd
@@ -397,6 +397,16 @@ func _make_cursor_circle_rect() -> ColorRect:
 	r.material = mat
 	return r
 
+func _make_triangle_rect() -> ColorRect:
+	var r = ColorRect.new()
+	r.name = "CompHandTriangle"
+	r.visible = true
+	r.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	var mat = ShaderMaterial.new()
+	mat.shader = preload("res://src/shaders/inverted_triangle.gdshader")
+	r.material = mat
+	return r
+
 func setup():
 	if not available:
 		main._log("[COMP] OpenXRCompositionLayerCylinder not available")
@@ -652,6 +662,55 @@ func setup_background_equirect():
 			main.comp_marker_left = marker_layer
 			main.comp_marker_left_circle = marker_circle
 	main._log("[COMP] Controller position marker composition layers created")
+
+	# Composite-only hand indicators (2026-08-27) - see main.gd's
+	# comp_hand_right/left comment for why this replaced an earlier full
+	# 3D-scene-in-a-viewport hand skeleton (too expensive even throttled to
+	# 14fps). Same disable_3d=true/no-offscreen-3D-scene shape as the
+	# controller markers just above, but the triangle's three vertices are
+	# live shader uniforms (inverted_triangle.gdshader's point_a/b/c) driven
+	# every frame from the wrist + two knuckle joints' real projected
+	# positions (main._update_one_hand_indicator()), not a fixed icon - the
+	# quad itself is also oriented to the hand's own plane, not billboarded
+	# to the camera, so the triangle's shape/orientation genuinely tracks
+	# hand pose in real time.
+	for side in ["right", "left"]:
+		var hand_layer = OpenXRCompositionLayerQuad.new()
+		hand_layer.name = "CompHand%sLayer" % side.capitalize()
+		hand_layer.set_sort_order(998)
+		hand_layer.set_enable_hole_punch(false)
+		hand_layer.set_alpha_blend(true)
+		hand_layer.set_quad_size(Vector2(main.HAND_INDICATOR_SIZE, main.HAND_INDICATOR_SIZE))
+		hand_layer.visible = false
+		main.xr_origin.add_child(hand_layer)
+
+		var hand_viewport = SubViewport.new()
+		hand_viewport.name = "CompHand%sViewport" % side.capitalize()
+		hand_viewport.disable_3d = true
+		hand_viewport.transparent_bg = true
+		# 256x256, not 64x64 (2026-08-27 fix) - the shader's own smoothstep
+		# antialiasing (inverted_triangle.gdshader's edge_soft) needs enough
+		# pixels to actually blend across, and at 64px on a 0.32m quad each
+		# pixel is ~5mm - reported as "very pixelated and blocky".
+		hand_viewport.size = Vector2i(256, 256)
+		hand_viewport.msaa_2d = Viewport.MSAA_4X
+		hand_viewport.render_target_update_mode = SubViewport.UPDATE_ALWAYS
+		main.add_child(hand_viewport)
+
+		var hand_triangle = _make_triangle_rect()
+		hand_triangle.anchors_preset = 15
+		hand_triangle.anchor_right = 1.0
+		hand_triangle.anchor_bottom = 1.0
+		hand_viewport.add_child(hand_triangle)
+
+		hand_layer.set_layer_viewport(hand_viewport)
+		if side == "right":
+			main.comp_hand_right = hand_layer
+			main.comp_hand_right_triangle = hand_triangle
+		else:
+			main.comp_hand_left = hand_layer
+			main.comp_hand_left_triangle = hand_triangle
+	main._log("[COMP] Hand indicator composition layers created")
 
 	# GLES already created its own comp_kb above (different sort order/log,
 	# same overall shape) - only create the non-GLES variant here to avoid

--- a/src/settings_controller.gd
+++ b/src/settings_controller.gd
@@ -116,6 +116,24 @@ const AUTO_TABLE := {
 	"21:9 2K": {false: {"tier": 1, "model_idx": 1, "cap_px": 0}, true: {"tier": 1, "model_idx": 0, "cap_px": 2560 * 1080}},
 	"4K":      {false: {"tier": 1, "model_idx": 0, "cap_px": 2560 * 1440}, true: {"tier": 1, "model_idx": 1, "cap_px": 2560 * 1440}},
 }
+
+# Quest 2 Auto table (2026-08-27) - NOT benchmarked on real Quest 2 hardware
+# (none available) - extrapolated from Meta's own published XR2 Gen 1 vs
+# Gen 2 GPU figures (roughly 2-2.5x slower on Quest 2, worse under sustained
+# thermal load) applied to the real Quest 3 benchmark data above. main.gd's
+# QUEST2_MAX_RESOLUTION already hard-caps the stream to 1080p before this
+# table is even consulted (Quest 2's own display is lower-res than Quest 3's
+# anyway, and dividing AUTO_TABLE's 4K/cap_px=2560x1440 entry by ~2.2x lands
+# almost exactly on 1080p's pixel count) - so only 720p/HD rows exist here,
+# always the cheapest surviving tier+model (Fast, MiDaS-192-GPU), with an
+# extra pixel-budget cap on HD+passthrough since passthrough adds real GPU
+# cost this hardware has much less headroom for. Treat as a starting point
+# to be corrected once real on-device Quest 2 feedback comes in, not a
+# measured result like the table above.
+const QUEST2_AUTO_TABLE := {
+	"720p": {false: {"tier": 1, "model_idx": 1, "cap_px": 0}, true: {"tier": 1, "model_idx": 1, "cap_px": 0}},
+	"HD":   {false: {"tier": 1, "model_idx": 1, "cap_px": 0}, true: {"tier": 1, "model_idx": 1, "cap_px": 1280 * 720}},
+}
 var idle_labels: Array = ["Off", "5m", "15m", "30m", "60m"]
 var idle_values: Array = [0, 5, 15, 30, 60]
 
@@ -178,6 +196,13 @@ func _classify_auto_resolution(w: int, h: int) -> String:
 func get_auto_selection() -> Dictionary:
 	var res: Vector2i = main.compute_requested_resolution(false)
 	var cls := _classify_auto_resolution(res.x, res.y)
+	if main.device_is_quest2:
+		# QUEST2_AUTO_TABLE only has 720p/HD rows (see its own comment) -
+		# QUEST2_MAX_RESOLUTION means classification should never actually
+		# produce anything above HD on Quest 2, but clamp defensively rather
+		# than throw if it somehow does.
+		var quest2_cls = cls if QUEST2_AUTO_TABLE.has(cls) else "HD"
+		return QUEST2_AUTO_TABLE[quest2_cls][main.passthrough_enabled]
 	return AUTO_TABLE[cls][main.passthrough_enabled]
 
 func _save_setting(btn: Button, label: String):

--- a/src/settings_controller.gd
+++ b/src/settings_controller.gd
@@ -415,21 +415,6 @@ func apply_stereo():
 			if main.primary_screen and main.primary_screen.comp_viewport:
 				main.primary_screen.comp_viewport.render_target_update_mode = SubViewport.UPDATE_ALWAYS
 			main.depth_estimator.bind_stream_texture()
-		if mode >= 3 and main.depth_estimator.depth_texture:
-			var de = main.depth_estimator
-			var upsampled_tex = de.upsample_viewport.get_texture() if de.upsample_viewport else null
-			var offset_tex = de.offset_viewport.get_texture() if de.offset_viewport else null
-			var guide_tex = de.depth_viewport.get_texture() if de.depth_viewport else null
-			if main.comp_shader_mat_left:
-				main.comp_shader_mat_left.set_shader_parameter("depth_texture", de.depth_texture)
-				main.comp_shader_mat_left.set_shader_parameter("upsampled_depth_texture", upsampled_tex)
-				main.comp_shader_mat_left.set_shader_parameter("offset_texture", offset_tex)
-				main.comp_shader_mat_left.set_shader_parameter("depth_guide_texture", guide_tex)
-			if main.comp_shader_mat_right:
-				main.comp_shader_mat_right.set_shader_parameter("depth_texture", de.depth_texture)
-				main.comp_shader_mat_right.set_shader_parameter("upsampled_depth_texture", upsampled_tex)
-				main.comp_shader_mat_right.set_shader_parameter("offset_texture", offset_tex)
-				main.comp_shader_mat_right.set_shader_parameter("depth_guide_texture", guide_tex)
 	# Which Java-side model/interpreter to run is entirely orthogonal to mode
 	# (stereo_mode only encodes speed tier / debug view, see ai_3d_models'
 	# comment above) - it comes straight from main.ai_3d_model. Modes
@@ -445,8 +430,36 @@ func apply_stereo():
 	var model_idx = get_depth_model_index() if mode >= 3 else 0
 	main.stream_backend.configure_depth(model_idx, get_depth_backend_index())
 	refresh_depth_backend_status(true)
+	# sync_model_size() (2026-08-27 - moved BEFORE the texture-capture block
+	# below, was after) resizes depth_viewport in place, which recreates
+	# its underlying render-target texture - reading/pushing
+	# de.depth_viewport.get_texture() etc. into the comp shader materials
+	# before this ran meant every model switch that actually changed size
+	# (e.g. 256<->192) pushed a texture reference that was about to go
+	# stale, confirmed via on-device logcat showing "Condition
+	# 't->is_render_target' is true" / "Parameter 'from_tex' is null"
+	# errors at the exact moment of a model switch, and reported as
+	# "sometimes stops loading the depth map" after switching models.
+	# configure_depth() above must still run first - sync_model_size()
+	# reads get_depth_model_size(), which only reflects the new model once
+	# the Java side has been reconfigured.
 	if mode >= 3 and main.depth_estimator:
 		main.depth_estimator.sync_model_size()
+		if main.depth_estimator.depth_texture:
+			var de = main.depth_estimator
+			var upsampled_tex = de.upsample_viewport.get_texture() if de.upsample_viewport else null
+			var offset_tex = de.offset_viewport.get_texture() if de.offset_viewport else null
+			var guide_tex = de.depth_viewport.get_texture() if de.depth_viewport else null
+			if main.comp_shader_mat_left:
+				main.comp_shader_mat_left.set_shader_parameter("depth_texture", de.depth_texture)
+				main.comp_shader_mat_left.set_shader_parameter("upsampled_depth_texture", upsampled_tex)
+				main.comp_shader_mat_left.set_shader_parameter("offset_texture", offset_tex)
+				main.comp_shader_mat_left.set_shader_parameter("depth_guide_texture", guide_tex)
+			if main.comp_shader_mat_right:
+				main.comp_shader_mat_right.set_shader_parameter("depth_texture", de.depth_texture)
+				main.comp_shader_mat_right.set_shader_parameter("upsampled_depth_texture", upsampled_tex)
+				main.comp_shader_mat_right.set_shader_parameter("offset_texture", offset_tex)
+				main.comp_shader_mat_right.set_shader_parameter("depth_guide_texture", guide_tex)
 
 func toggle_passthrough():
 	if not main.is_xr_active or not main.passthrough_supported:

--- a/src/shaders/inverted_triangle.gdshader
+++ b/src/shaders/inverted_triangle.gdshader
@@ -1,0 +1,37 @@
+shader_type canvas_item;
+
+// Same alpha_mult convention as circle_cursor.gdshader (main.gd's
+// MARKER_IDLE_ALPHA etc) - COLOR is fully overwritten below, so node
+// .modulate has no effect; this uniform is the only opacity control.
+uniform float alpha_mult : hint_range(0.0, 1.0) = 1.0;
+
+// Live triangle vertices in UV space [0,1]^2 (2026-08-27) - set every frame
+// by main.gd's _update_one_hand_indicator() from the wrist and two
+// knuckle joints' real projected positions, replacing the original fixed
+// triangle shape. Defaults here only matter before the first real update.
+uniform vec2 point_a = vec2(0.12, 0.12);
+uniform vec2 point_b = vec2(0.5, 0.88);
+uniform vec2 point_c = vec2(0.88, 0.12);
+
+// Signed distance to the line through a-b, in UV space. Sign depends on
+// winding direction - only used relative to itself below, so that's fine.
+float edge_dist(vec2 p, vec2 a, vec2 b) {
+	vec2 ab = b - a;
+	vec2 ap = p - a;
+	return (ab.x * ap.y - ab.y * ap.x) / max(length(ab), 0.0001);
+}
+
+void fragment() {
+	// Normalize all three edge distances to the same "inside" sign as the
+	// first edge, so this works regardless of the triangle's own winding
+	// direction (any simple triangle is convex, so this is safe).
+	float s = sign(edge_dist(UV, point_a, point_b));
+	float d1 = edge_dist(UV, point_a, point_b) * s;
+	float d2 = edge_dist(UV, point_b, point_c) * s;
+	float d3 = edge_dist(UV, point_c, point_a) * s;
+	float inside = min(min(d1, d2), d3);
+
+	float edge_soft = 0.015;
+	float alpha = smoothstep(0.0, edge_soft, inside);
+	COLOR = vec4(1.0, 1.0, 1.0, alpha * 0.5 * alpha_mult);
+}

--- a/src/stream_backend.gd
+++ b/src/stream_backend.gd
@@ -260,6 +260,13 @@ func get_depth_last_inference_hz() -> float:
 			return db.get_depth_last_inference_hz()
 	return 0.0
 
+func get_device_model() -> String:
+	if _v2:
+		var db = _v2.get_depth_bridge()
+		if db:
+			return db.get_device_model()
+	return ""
+
 func probe_video_format(codec_pref: int, disable_hw: bool) -> int:
 	if _v2:
 		return _v2.probe_video_format(codec_pref, disable_hw)


### PR DESCRIPTION
## Summary
- Replaces the old (invisible-under-projectionless) palm+index hand mesh with a lightweight composite-only triangle indicator per hand - three vertices (wrist, index knuckle, pinky knuckle) driven live from real joint data every frame, same cost profile as the existing controller markers. A full 3D-scene-in-a-viewport skeleton and a controller render-model experiment were both tried and reverted after tanking performance.
- Adds Quest 2 detection (Android `Build.DEVICE` via a new JNI bridge - `Build.MODEL` itself is useless, confirmed on real hardware to just return `"Quest"` regardless of generation) with a 1080p resolution ceiling and a simplified AI-3D Auto table for it, extrapolated from Quest 3's real benchmarked table and Meta's published XR2 Gen1-vs-Gen2 GPU gap - flagged as unvalidated on real Quest 2 hardware pending user feedback.
- Fixes an intermittent "depth map stops loading" bug when switching AI-3D models - `apply_stereo()` was pushing `depth_viewport`'s texture into the comp shader materials *before* `sync_model_size()` resized that same viewport (recreating its render-target texture), leaving a stale reference. Confirmed via on-device logcat at the exact moment of a model switch.

## Test plan
- [x] On-device (Quest 3): hand-tracking triangle indicator tested and iterated on live (joint mapping, quad-size clipping, projection sign, viewport resolution) until confirmed correct and non-pixelated.
- [x] On-device: confirmed device detection correctly identifies this Quest 3 (`Build.DEVICE='eureka'`) as not-Quest-2, no regression to existing behavior.
- [x] On-device: confirmed the depth-viewport fix - reproduced the original texture errors via logcat, verified they no longer occur after the reorder.
- [ ] Quest 2 Auto table/resolution cap - not tested on real Quest 2 hardware (none available); pending feedback from the reporting user.